### PR TITLE
fix: measured times for application startup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=7.3",
         "illuminate/routing": "^5.5|^6",
         "illuminate/support": "^5.5|^6",
-        "philkra/elastic-apm-php-agent": "dev-master"
+        "philkra/elastic-apm-php-agent": "dev-master",
+        "jasny/dbquery-mysql": "^2.0"
     },
     "repositories": [
         {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -39,7 +39,7 @@ class Agent extends PhilKraAgent
         // Timeline collector
         $this->collectors->put(
             TimelineDataCollector::getName(),
-            new TimelineDataCollector()
+            new TimelineDataCollector($this->request_start_time)
         );
 
         // DB Queries collector

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -3,8 +3,7 @@ namespace AG\ElasticApmLaravel\Collectors;
 
 use Exception;
 
-use Illuminate\Events\Dispatcher;
-use Illuminate\Support\Collection;
+use Illuminate\Foundation\Application;
 use Illuminate\Database\Events\QueryExecuted;
 
 use Jasny\DB\MySQL\QuerySplitter;
@@ -17,6 +16,23 @@ use AG\ElasticApmLaravel\Collectors\Interfaces\DataCollectorInterface;
  */
 class DBQueryCollector extends TimelineDataCollector implements DataCollectorInterface
 {
+    protected $app;
+
+    public function __construct(Application $app, float $request_start_time)
+    {
+        parent::__construct($request_start_time);
+
+        $this->app = $app;
+        $this->registerEventListeners();
+    }
+
+    protected function registerEventListeners(): void
+    {
+        $this->app->events->listen(QueryExecuted::class, function (QueryExecuted $query) {
+            $this->onQueryExecutedEvent($query);
+        });
+    }
+
     public function onQueryExecutedEvent(QueryExecuted $query): void
     {
 

--- a/src/Collectors/HttpRequestCollector.php
+++ b/src/Collectors/HttpRequestCollector.php
@@ -61,7 +61,7 @@ class HttpRequestCollector extends TimelineDataCollector implements DataCollecto
         });
     }
 
-    protected function getController()
+    protected function getController(): ?string
     {
         $router = $this->app['router'];
 

--- a/src/Collectors/HttpRequestCollector.php
+++ b/src/Collectors/HttpRequestCollector.php
@@ -1,0 +1,87 @@
+<?php
+namespace AG\ElasticApmLaravel\Collectors;
+
+use Exception;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Foundation\Http\Events\RequestHandled;
+
+use Jasny\DB\MySQL\QuerySplitter;
+
+use AG\ElasticApmLaravel\Collectors\TimelineDataCollector;
+use AG\ElasticApmLaravel\Collectors\Interfaces\DataCollectorInterface;
+
+/**
+ * Collects info about the http request process
+ */
+class HttpRequestCollector extends TimelineDataCollector implements DataCollectorInterface
+{
+    protected $app;
+
+    public function __construct(Application $app, float $request_start_time)
+    {
+        parent::__construct($request_start_time);
+
+        $this->app = $app;
+        $this->registerEventListeners();
+    }
+
+    protected function registerEventListeners(): void
+    {
+        $start_time = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
+
+        // Application and Laravel startup times
+        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', $start_time);
+        
+        $this->app->booting(function () {
+            $this->startMeasure('laravel_boot', 'laravel', 'boot', 'Laravel boot');
+            $this->stopMeasure('app_boot');
+        });
+        
+        $this->app->booted(function () {
+            $this->startMeasure('route_matching', 'laravel', 'request', 'Route matching');
+            if ($this->hasStartedMeasure('laravel_boot')) {
+                $this->stopMeasure('laravel_boot');
+            }
+        });
+
+        // Time between route resolution and request handled
+        $this->app->events->listen(RouteMatched::class, function () {
+            $this->startMeasure('request_handled', 'laravel', 'request', $this->getController());
+            if ($this->hasStartedMeasure('route_matching')) {
+                $this->stopMeasure('route_matching');
+            }
+        });
+
+        $this->app->events->listen(RequestHandled::class, function () {
+            if ($this->hasStartedMeasure('request_handled')) {
+                $this->stopMeasure('request_handled');
+            }
+        });
+    }
+
+    protected function getController()
+    {
+        $router = $this->app['router'];
+
+        $route = $router->current();
+        $controller = $route ? $route->getActionName() : null;
+
+        if ($controller instanceof \Closure) {
+            $controller = 'anonymous function';
+        } elseif (is_object($controller)) {
+            $controller = 'instance of ' . get_class($controller);
+        } elseif (is_array($controller) && count($controller) == 2) {
+            if (is_object($controller[0])) {
+                $controller = get_class($controller[0]) . '->' . $controller[1];
+            } else {
+                $controller = $controller[0] . '::' . $controller[1];
+            }
+        } elseif (! is_string($controller)) {
+            $controller = null;
+        }
+
+        return $controller;
+    }
+}

--- a/src/Collectors/HttpRequestCollector.php
+++ b/src/Collectors/HttpRequestCollector.php
@@ -29,10 +29,10 @@ class HttpRequestCollector extends TimelineDataCollector implements DataCollecto
 
     protected function registerEventListeners(): void
     {
-        $start_time = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
-
         // Application and Laravel startup times
-        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', $start_time);
+        // LARAVEL_START is defined at the entry point of the application
+        // https://github.com/laravel/laravel/blob/master/public/index.php#L10
+        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', LARAVEL_START);
         
         $this->app->booting(function () {
             $this->startMeasure('laravel_boot', 'laravel', 'boot', 'Laravel boot');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,16 +1,12 @@
 <?php
 namespace AG\ElasticApmLaravel;
 
-use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Routing\Events\RouteMatched;
-use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 use PhilKra\Helper\Timer;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Contracts\VersionResolver;
-use AG\ElasticApmLaravel\Collectors\TimelineDataCollector;
 use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
 
 class ServiceProvider extends BaseServiceProvider
@@ -36,11 +32,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->mergeConfigFrom($this->source_config_path, 'elastic-apm-laravel');
         $this->registerAgent();
-         
-        $this->listenForEvents();
-        if (config('elastic-apm.spans.querylog.enabled') !== false) {
-            $this->listenForQueries();
-        }
+        $this->registerCollectors();
     }
 
     /**
@@ -51,44 +43,18 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(Agent::class, function () {
             $start_time = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
             $agent = new Agent($this->getAgentConfig(), $start_time);
-            $agent->registerCollectors();
 
             return $agent;
         });
     }
 
-    protected function listenForEvents(): void
+    /**
+     * Register data collectors and start listening for events
+     */
+    protected function registerCollectors(): void
     {
-        $start_time = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
-        $timeline_collector = $this->app->make(Agent::class)->getCollector(TimelineDataCollector::getName());
-        
-        // Application and Laravel startup times
-        $timeline_collector->startMeasure('app_boot', 'app', 'boot', 'App boot', $start_time);
-        $this->app->booting(function () use ($timeline_collector) {
-            $timeline_collector->stopMeasure('app_boot');
-            $timeline_collector->startMeasure('laravel_boot', 'laravel', 'boot', 'Laravel boot');
-        });
-        $this->app->booted(function () use ($timeline_collector) {
-            $timeline_collector->stopMeasure('laravel_boot');
-        });
-
-        // Time between route resolution and request handled
-        $this->app->events->listen(RouteMatched::class, function () use ($timeline_collector) {
-            $timeline_collector->startMeasure('request_handled', 'laravel', 'request', $this->getController());
-        });
-        $this->app->events->listen(RequestHandled::class, function () use ($timeline_collector) {
-            if ($timeline_collector->hasStartedMeasure('request_handled')) {
-                $timeline_collector->stopMeasure('request_handled');
-            }
-        });
-    }
-
-    protected function listenForQueries(): void
-    {
-        $query_collector = $this->app->make(Agent::class)->getCollector(DBQueryCollector::getName());
-        $this->app->events->listen(QueryExecuted::class, function (QueryExecuted $query) use ($query_collector) {
-            $query_collector->onQueryExecutedEvent($query);
-        });
+        $agent = $this->app->make(Agent::class);
+        $agent->registerCollectors($this->app);
     }
 
     /**
@@ -136,29 +102,5 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         return $config;
-    }
-
-    protected function getController()
-    {
-        $router = $this->app['router'];
-
-        $route = $router->current();
-        $controller = $route ? $route->getActionName() : null;
-
-        if ($controller instanceof \Closure) {
-            $controller = 'anonymous function';
-        } elseif (is_object($controller)) {
-            $controller = 'instance of ' . get_class($controller);
-        } elseif (is_array($controller) && count($controller) == 2) {
-            if (is_object($controller[0])) {
-                $controller = get_class($controller[0]) . '->' . $controller[1];
-            } else {
-                $controller = $controller[0] . '::' . $controller[1];
-            }
-        } elseif (! is_string($controller)) {
-            $controller = null;
-        }
-
-        return $controller;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,7 +7,6 @@ use PhilKra\Helper\Timer;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Contracts\VersionResolver;
-use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
 
 class ServiceProvider extends BaseServiceProvider
 {


### PR DESCRIPTION
Split the startup time in two:
- Application load time, usually taken by Composer, file reading, etc
- Framework load, measured by Laravel's events `booting` and `booted`.

Add the time that it takes for a request to be handled, measured by the time between `RouteMatched` and `RequestHandled` events. I suppose this also includes middlewares.

Add the query name: query type + target tables.

<img width="1173" alt="Screenshot 2020-01-24 at 09 50 27" src="https://user-images.githubusercontent.com/1712467/73058044-1617e200-3e93-11ea-97a7-040e0c1b0ebe.png">
