### PR TITLE
chore: respect configuration when registering services

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -37,7 +37,7 @@ class Agent extends PhilKraAgent
 
     public function registerCollectors(Application $app): void
     {
-        if (config('elastic-apm.spans.querylog.enabled') !== false) {
+        if (config('elastic-apm-laravel.spans.querylog.enabled') !== false) {
             // DB Queries collector
             $this->collectors->put(
                 DBQueryCollector::getName(),
@@ -59,7 +59,7 @@ class Agent extends PhilKraAgent
 
     public function collectEvents(string $transaction_name): void
     {
-        $max_trace_items = config('elastic-apm.spans.maxTraceItems');
+        $max_trace_items = config('elastic-apm-laravel.spans.maxTraceItems');
 
         $transaction = $this->getTransaction($transaction_name);
         $this->collectors->each(function ($collector) use ($transaction, $max_trace_items) {

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -36,8 +36,8 @@ class DBQueryCollector extends TimelineDataCollector implements DataCollectorInt
     public function onQueryExecutedEvent(QueryExecuted $query): void
     {
 
-        if (config('elastic-apm.spans.querylog.enabled') === 'auto') {
-            if ($query->time < config('elastic-apm.spans.querylog.threshold')) {
+        if (config('elastic-apm-laravel.spans.querylog.enabled') === 'auto') {
+            if ($query->time < config('elastic-apm-laravel.spans.querylog.threshold')) {
                 return;
             }
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,9 +29,6 @@ class ServiceProvider extends BaseServiceProvider
      */
     public function register(): void
     {
-        if (!config('elastic-apm-laravel.active')) {
-            return;
-        }
         $this->mergeConfigFrom($this->source_config_path, 'elastic-apm-laravel');
         $this->registerAgent();
         $this->registerCollectors();
@@ -55,6 +52,10 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function registerCollectors(): void
     {
+        if (config('elastic-apm-laravel.active') === false) {
+            return;
+        }
+
         $agent = $this->app->make(Agent::class);
         $agent->registerCollectors($this->app);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,6 +29,9 @@ class ServiceProvider extends BaseServiceProvider
      */
     public function register(): void
     {
+        if (!config('elastic-apm-laravel.active')) {
+            return;
+        }
         $this->mergeConfigFrom($this->source_config_path, 'elastic-apm-laravel');
         $this->registerAgent();
         $this->registerCollectors();


### PR DESCRIPTION
`LARAVEL_START` is not defined when running tests with Codeception, so I'd apply a hammer solution to use that config option to prevent loading services when we set it.