### PR TITLE
feat: request URI as transaction name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following environment variables are supported in the default configuration:
 |APM_APPVERSION     | Version of the app as it will appear in APM. |
 |APM_SERVERURL      | URL to the APM intake service. |
 |APM_SECRETTOKEN    | Secret token, if required. |
+|APM_USEROUTEURI    | `true` or `false` defaults to `true`. The default behavior is to record the URL as defined in your routes configuration. Set to `false` to record the requested URL, but keep in mind that this can result in excessive unique entries in APM. |
 |APM_QUERYLOG       | `true` or `false` defaults to 'true'. Set to `false` to completely disable query logging, or to `auto` if you would like to use the threshold feature. |
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |

--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -34,6 +34,13 @@ return [
         'hostname' => gethostname(),
     ],
 
+    'transactions' => [
+
+        //This option will bundle transaction on the route name without variables
+        'use_route_uri' => env('APM_USEROUTEURI', true),
+
+    ],
+
     'spans' => [
         // Max number of child items displayed when viewing trace details.
         'maxTraceItems'=> env('APM_MAXTRACEITEMS', 1000),


### PR DESCRIPTION
Use Laravel's URI route name as transaction name. This will make routes to appear grouped in APM, instead of showing an entry for each URL. It will help to reduce the noise in the transaction list.

![Screenshot 2020-02-07 at 13 12 18](https://user-images.githubusercontent.com/1712467/74029431-fad9c600-49ac-11ea-9169-8355305fd7d7.png)

A configuration option it's available to log full URIs, if that's desired.
