### PR TITLE
Job tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Elastic APM 
+# Elastic APM
 
 Elastic APM agent for v2 intake API. Compatible with Laravel 5.5+.
 
@@ -18,6 +18,17 @@ Add the ServiceProvider class to the providers array in `config/app.php`:
 ```
 
 From here, we will take care of everything based on your configuration. The agent and the middleware will be registered, and transactions will be send to Elastic.
+
+However, there is a caveat if you'd like to include Job tracking. You must include Job middleware manually or these transactions will not be recorded (Laravel 6+ only https://laravel.com/docs/6.x/queues#job-middleware):
+
+```php
+public function middleware()
+{
+    return [
+        app(\AG\ElasticApmLaravel\Jobs\Middleware\RecordTransaction::class),
+    ];
+}
+```
 
 ## Agent configuration
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -9,6 +9,8 @@ use AG\ElasticApmLaravel\Events\LazySpan;
 use AG\ElasticApmLaravel\Collectors\Interfaces\DataCollectorInterface;
 use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
 use AG\ElasticApmLaravel\Collectors\HttpRequestCollector;
+use AG\ElasticApmLaravel\Collectors\FrameworkCollector;
+use AG\ElasticApmLaravel\Collectors\JobCollector;
 
 /**
  * The Elastic APM agent sends performance metrics and error logs to the APM Server.
@@ -45,10 +47,22 @@ class Agent extends PhilKraAgent
             );
         }
 
+        // Laravel init collector
+        $this->collectors->put(
+            FrameworkCollector::getName(),
+            new FrameworkCollector($app, $this->request_start_time)
+        );
+
         // Http request collector
         $this->collectors->put(
             HttpRequestCollector::getName(),
             new HttpRequestCollector($app, $this->request_start_time)
+        );
+
+        // Job collector
+        $this->collectors->put(
+            JobCollector::getName(),
+            new JobCollector($app, $this, $this->request_start_time)
         );
     }
 

--- a/src/Collectors/FrameworkCollector.php
+++ b/src/Collectors/FrameworkCollector.php
@@ -1,0 +1,47 @@
+<?php
+namespace AG\ElasticApmLaravel\Collectors;
+
+use Illuminate\Foundation\Application;
+
+use AG\ElasticApmLaravel\Collectors\TimelineDataCollector;
+use AG\ElasticApmLaravel\Collectors\Interfaces\DataCollectorInterface;
+
+/**
+ * Collects info about the Laravel initialization.
+ */
+class FrameworkCollector extends TimelineDataCollector implements DataCollectorInterface
+{
+    protected $app;
+
+    public function __construct(Application $app, float $request_start_time)
+    {
+        parent::__construct($request_start_time);
+
+        $this->app = $app;
+        $this->registerEventListeners();
+    }
+
+    public static function getName() : string
+    {
+        return 'framework-collector';
+    }
+
+    protected function registerEventListeners(): void
+    {
+        // Application and Laravel startup times
+        // LARAVEL_START is defined at the entry point of the application
+        // https://github.com/laravel/laravel/blob/master/public/index.php#L10
+        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', LARAVEL_START);
+
+        $this->app->booting(function () {
+            $this->startMeasure('laravel_boot', 'laravel', 'boot', 'Laravel boot');
+            $this->stopMeasure('app_boot');
+        });
+
+        $this->app->booted(function () {
+            if ($this->hasStartedMeasure('laravel_boot')) {
+                $this->stopMeasure('laravel_boot');
+            }
+        });
+    }
+}

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AG\ElasticApmLaravel\Collectors;
+
+use AG\ElasticApmLaravel\Agent;
+use AG\ElasticApmLaravel\Collectors\Interfaces\DataCollectorInterface;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+
+/**
+ * Collects info about the http request process
+ */
+class JobCollector extends TimelineDataCollector implements DataCollectorInterface
+{
+    protected $app;
+    protected $agent;
+
+    public function __construct(Application $app, Agent $agent, float $request_start_time)
+    {
+        $this->app = $app;
+        parent::__construct($request_start_time);
+
+        $this->agent = $agent;
+        $this->registerEventListeners();
+    }
+
+    public static function getName(): string
+    {
+        return 'job-collector';
+    }
+
+    protected function registerEventListeners(): void
+    {
+        $this->app->events->listen(JobProcessing::class, function () {
+            $this->startMeasure('job_processing', 'job', 'processing', 'Job processing');
+        });
+
+        $this->app->events->listen(JobProcessed::class, function () {
+            if ($this->hasStartedMeasure('job_processing')) {
+                $this->stopMeasure('job_processing');
+            }
+        });
+    }
+}

--- a/src/Jobs/Middleware/RecordTransaction.php
+++ b/src/Jobs/Middleware/RecordTransaction.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace AG\ElasticApmLaravel\Jobs\Middleware;
+
+use AG\ElasticApmLaravel\Agent;
+use Illuminate\Support\Facades\Log;
+use PhilKra\Events\Transaction;
+use Throwable;
+
+class RecordTransaction
+{
+    /** @var Agent */
+    private $agent;
+
+    public function __construct(Agent $agent)
+    {
+        $this->agent = $agent;
+    }
+
+    /**
+     * Wrap the job processing in an APM transaction.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        if (config('elastic-apm-agent.active') === false) {
+            return $next($job);
+        }
+
+        $transaction = $this->startTransaction($this->getTransactionName($job));
+
+        $next($job);
+
+        $this->addMetadata($transaction, $job);
+
+        $this->stopTransaction($job);
+    }
+
+    public function addMetadata(Transaction $transaction, $job): void
+    {
+        $transaction->setMeta([
+            'type' => 'job'
+        ]);
+    }
+
+    /**
+     * Start the transaction that will measure the job, application start up time, DB queries, etc
+     */
+    protected function startTransaction(string $transaction_name): Transaction
+    {
+        return $this->agent->startTransaction(
+            $transaction_name,
+            [],
+            $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true)
+        );
+    }
+
+    protected function stopTransaction($job) : void
+    {
+        try {
+            $transaction_name = $this->getTransactionName($job);
+
+            // Stop the transaction and measure the time
+            $this->agent->stopTransaction($transaction_name);
+            $this->agent->sendTransaction($transaction_name);
+        } catch (Throwable $t) {
+            Log::error($t->getMessage());
+        }
+    }
+
+    protected function getTransactionName($job)
+    {
+        return get_class($job);
+    }
+}


### PR DESCRIPTION
Add job tracking via middleware available in Laravel 6+ as well as via job events.

This splits framework init into its own collector so that it doesn't log duplicates between HTTP and Job.