### PR TITLE
Protect from invalid app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following environment variables are supported in the default configuration:
 | Variable          | Description |
 |-------------------|-------------|
 |APM_ACTIVE         | `true` or `false` defaults to `true`. If `false`, the agent will collect, but not send, transaction data. |
-|APM_APPNAME        | Name of the app as it will appear in APM. |
+|APM_APPNAME        | Name of the app as it will appear in APM. Invalid special characters will be replaced with a hyphen. |
 |APM_APPVERSION     | Version of the app as it will appear in APM. |
 |APM_SERVERURL      | URL to the APM intake service. |
 |APM_SECRETTOKEN    | Secret token, if required. |

--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -5,8 +5,8 @@ return [
     'active' => env('APM_ACTIVE', true),
 
     'app' => [
-        // The app name that will identify your app in Kibana / Elastic APM
-        'appName' => env('APM_APPNAME', 'Laravel'),
+        // The app name that will identify your app in Kibana / Elastic APM, limited characters allowed
+        'appName' => preg_replace('/[^a-zA-Z0-9 _-]/', '-', env('APM_APPNAME', 'Laravel')),
 
         // The version of your app
         'appVersion' => env('APM_APPVERSION', ''),

--- a/tests/ApmConfigTest.php
+++ b/tests/ApmConfigTest.php
@@ -70,7 +70,7 @@ class ApmConfigTest extends \Codeception\Test\Unit
         putenv('APM_APPNAME="Codeception?App"');
         $config = include($this->configFilePath);
 
-        $this->assertEquals('Codeception?App', $config['app']['appName']);
+        $this->assertEquals('Codeception-App', $config['app']['appName']);
     }
 
     public function testEnvConfigVariables()


### PR DESCRIPTION
Replace invalid app name characters with a hyphen.