### PR TITLE
chore: rename timeline collector

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -1,7 +1,6 @@
-namespace: AG\Tests
 suites:
     unit:
-        path: .
+        path: unit
 
 settings:
     shuffle: true

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -50,7 +50,7 @@ class Agent extends PhilKraAgent
         $this->addCollector(app(SpanCollector::class));
     }
 
-    public function addCollector(DataCollector $collector)
+    public function addCollector(DataCollector $collector): void
     {
         $this->collectors->put(
             $collector->getName(),
@@ -92,7 +92,7 @@ class Agent extends PhilKraAgent
         return parent::send();
     }
 
-    public function getRequestStartTime()
+    public function getRequestStartTime(): float
     {
         return $this->request_start_time;
     }

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -10,7 +10,7 @@ use Jasny\DB\MySQL\QuerySplitter;
 /**
  * Collects info about the database executed queries.
  */
-class DBQueryCollector extends TimelineDataCollector implements DataCollector
+class DBQueryCollector extends EventDataCollector implements DataCollector
 {
     public function getName(): string
     {

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -17,7 +17,14 @@ class DBQueryCollector extends EventDataCollector implements DataCollector
         return 'query-collector';
     }
 
-    public function onQueryExecutedEvent(QueryExecuted $query): void
+    public function registerEventListeners(): void
+    {
+        $this->app->events->listen(QueryExecuted::class, function (QueryExecuted $query) {
+            $this->onQueryExecutedEvent($query);
+        });
+    }
+
+    private function onQueryExecutedEvent(QueryExecuted $query): void
     {
         if ('auto' === config('elastic-apm-laravel.spans.querylog.enabled')) {
             if ($query->time < config('elastic-apm-laravel.spans.querylog.threshold')) {
@@ -50,13 +57,6 @@ class DBQueryCollector extends EventDataCollector implements DataCollector
             $query['action'],
             $query['context']
         );
-    }
-
-    protected function registerEventListeners(): void
-    {
-        $this->app->events->listen(QueryExecuted::class, function (QueryExecuted $query) {
-            $this->onQueryExecutedEvent($query);
-        });
     }
 
     private function getQueryName(string $sql): string

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -4,22 +4,15 @@ namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Collects info about the request duration as well as providing
- * a way to log duration of any operations.
+ * Abstract class that provides base functionality to measure
+ * events dispatched by the framnewrok or your application code.
  */
-abstract class TimelineDataCollector implements DataCollector
+abstract class EventDataCollector implements DataCollector
 {
-    /** @var Application */
-    protected $app;
-
-    /** @var Agent */
-    protected $agent;
-
     /** @var Collection */
     protected $started_measures;
 
@@ -29,22 +22,14 @@ abstract class TimelineDataCollector implements DataCollector
     /** @var float */
     protected $request_start_time;
 
-    public function __construct(Application $app, Agent $agent)
+    public function __construct(Agent $agent)
     {
-        $this->app = $app;
-        $this->agent = $agent;
-
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 
-        $this->request_start_time = $this->agent->getRequestStartTime();
+        $this->request_start_time = $agent->getRequestStartTime();
 
         $this->registerEventListeners();
-    }
-
-    public function getName(): string
-    {
-        return 'timeline';
     }
 
     /**
@@ -131,10 +116,6 @@ abstract class TimelineDataCollector implements DataCollector
         });
 
         return $this->measures;
-    }
-
-    protected function registerEventListeners(): void
-    {
     }
 
     private function toMilliseconds(float $time): float

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -4,6 +4,7 @@ namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 
@@ -13,6 +14,12 @@ use Illuminate\Support\Facades\Log;
  */
 abstract class EventDataCollector implements DataCollector
 {
+    /** @var Application */
+    protected $app;
+
+    /** @var Agent */
+    protected $agent;
+
     /** @var Collection */
     protected $started_measures;
 
@@ -22,8 +29,10 @@ abstract class EventDataCollector implements DataCollector
     /** @var float */
     protected $request_start_time;
 
-    public function __construct(Agent $agent)
+    public function __construct(Application $app, Agent $agent)
     {
+        $this->app = $app;
+        $this->agent = $agent;
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 

--- a/src/Collectors/HttpRequestCollector.php
+++ b/src/Collectors/HttpRequestCollector.php
@@ -10,7 +10,7 @@ use Illuminate\Routing\Events\RouteMatched;
 /**
  * Collects info about the http request process.
  */
-class HttpRequestCollector extends TimelineDataCollector implements DataCollector
+class HttpRequestCollector extends EventDataCollector implements DataCollector
 {
     protected function registerEventListeners(): void
     {

--- a/src/Collectors/HttpRequestCollector.php
+++ b/src/Collectors/HttpRequestCollector.php
@@ -12,7 +12,12 @@ use Illuminate\Routing\Events\RouteMatched;
  */
 class HttpRequestCollector extends EventDataCollector implements DataCollector
 {
-    protected function registerEventListeners(): void
+    public function getName(): string
+    {
+        return 'request-collector';
+    }
+
+    public function registerEventListeners(): void
     {
         // Application and Laravel startup times
         // LARAVEL_START is defined at the entry point of the application
@@ -36,7 +41,11 @@ class HttpRequestCollector extends EventDataCollector implements DataCollector
         });
 
         $this->app->events->listen(RequestHandled::class, function () {
-            $this->stopMeasure('request_handled');
+            // Some middlewares might return a response
+            // before the RouteMatched has been dispatched
+            if ($this->hasStartedMeasure('request_handled')) {
+                $this->stopMeasure('request_handled');
+            }
         });
     }
 

--- a/src/Collectors/SpanCollector.php
+++ b/src/Collectors/SpanCollector.php
@@ -16,7 +16,7 @@ class SpanCollector extends EventDataCollector implements DataCollector
         return 'span-collector';
     }
 
-    protected function registerEventListeners(): void
+    public function registerEventListeners(): void
     {
         $this->app->events->listen(StartMeasuring::class, function (StartMeasuring $event) {
             $this->startMeasure(

--- a/src/Collectors/SpanCollector.php
+++ b/src/Collectors/SpanCollector.php
@@ -9,7 +9,7 @@ use AG\ElasticApmLaravel\Events\StopMeasuring;
 /**
  * Generic collector for spans measured manually throughout the app.
  */
-class SpanCollector extends TimelineDataCollector implements DataCollector
+class SpanCollector extends EventDataCollector implements DataCollector
 {
     public function getName(): string
     {

--- a/src/Contracts/DataCollector.php
+++ b/src/Contracts/DataCollector.php
@@ -9,4 +9,6 @@ interface DataCollector
     public function collect(): Collection;
 
     public function getName(): string;
+
+    public function registerEventListeners(): void;
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,15 +13,7 @@ class ServiceProvider extends BaseServiceProvider
     private $source_config_path = __DIR__ . '/../config/elastic-apm-laravel.php';
 
     /**
-     * Bootstrap the application events.
-     */
-    public function boot(): void
-    {
-        $this->publishConfig();
-    }
-
-    /**
-     * Register the service provider.
+     * Register the package Facade and APM agent.
      */
     public function register(): void
     {
@@ -35,6 +27,20 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->registerAgent();
+    }
+
+    /**
+     * Add the global transaction middleware
+     * and default event collectors.
+     */
+    public function boot(): void
+    {
+        $this->publishConfig();
+
+        if (false === config('elastic-apm-laravel.active')) {
+            return;
+        }
+
         $this->registerMiddleware();
         $this->registerCollectors();
     }

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -2,11 +2,33 @@
 
 namespace AG\ElasticApmLaravel\Services;
 
+use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Events\StartMeasuring;
 use AG\ElasticApmLaravel\Events\StopMeasuring;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
 
 class ApmCollectorService
 {
+    /**
+     * @var Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * @var Illuminate\Events\Dispatcher
+     */
+    protected $events;
+
+    public function __construct(Application $app, Dispatcher $events, Config $config)
+    {
+        $this->app = $app;
+        $this->events = $events;
+
+        $this->is_agent_disabled = false === $config->get('elastic-apm-laravel.active');
+    }
+
     public function startMeasure(
         string $name,
         string $type = 'request',
@@ -14,13 +36,37 @@ class ApmCollectorService
         ?string $label = null,
         ?float $start_time = null
     ) {
-        event(new StartMeasuring($name, $type, $action, $label, $start_time));
+        $this->events->dispatch(
+            new StartMeasuring(
+                $name,
+                $type,
+                $action,
+                $label,
+                $start_time
+            )
+        );
     }
 
     public function stopMeasure(
         string $name,
         array $params = []
     ) {
-        event(new StopMeasuring($name, $params));
+        $this->events->dispatch(
+            new StopMeasuring(
+                $name,
+                $params
+            )
+        );
+    }
+
+    public function addCollector(string $collector_class): void
+    {
+        if ($this->is_agent_disabled) {
+            return;
+        }
+
+        $this->app->make(Agent::class)->addCollector(
+            $this->app->make($collector_class)
+        );
     }
 }

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -4,7 +4,6 @@ use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
 use Codeception\Test\Unit;
 use DMS\PHPUnitExtensions\ArraySubset\Assert;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Log;
 
 class CustomCollector extends EventDataCollector

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -36,7 +36,10 @@ class CustomCollectorTest extends Unit
         $appMock = Mockery::mock(Application::class);
         $agentMock = Mockery::mock(Agent::class);
 
-        $agentMock->shouldReceive('getRequestStartTime')->andReturn(1000.0);
+        $agentMock->shouldReceive('getRequestStartTime')
+            ->once()
+            ->andReturn(1000.0);
+
         Log::shouldReceive('info')
             ->once()
             ->with('registerEventListeners method has been called.');

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -4,6 +4,7 @@ use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
 use Codeception\Test\Unit;
 use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Log;
 
 class CustomCollector extends EventDataCollector
@@ -32,14 +33,15 @@ class CustomCollectorTest extends Unit
 
     protected function _before()
     {
-        $this->agentMock = Mockery::mock(Agent::class);
+        $appMock = Mockery::mock(Application::class);
+        $agentMock = Mockery::mock(Agent::class);
 
-        $this->agentMock->shouldReceive('getRequestStartTime')->andReturn(1000.0);
+        $agentMock->shouldReceive('getRequestStartTime')->andReturn(1000.0);
         Log::shouldReceive('info')
             ->once()
             ->with('registerEventListeners method has been called.');
 
-        $this->collector = new CustomCollector($this->agentMock);
+        $this->collector = new CustomCollector($appMock, $agentMock);
     }
 
     public function testEmptyMeasures()

--- a/tests/unit/Events/LazySpanTest.php
+++ b/tests/unit/Events/LazySpanTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace AG\Tests\Events;
-
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Codeception\Test\Unit;
 use PhilKra\Events\EventBean;

--- a/tests/unit/Events/StartMeasuringTest.php
+++ b/tests/unit/Events/StartMeasuringTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace AG\Tests\Events;
-
 use AG\ElasticApmLaravel\Events\StartMeasuring;
 use Codeception\Test\Unit;
 

--- a/tests/unit/Events/StopMeasuringTest.php
+++ b/tests/unit/Events/StopMeasuringTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace AG\Tests\Events;
-
 use AG\ElasticApmLaravel\Events\StopMeasuring;
 use Codeception\Test\Unit;
 

--- a/tests/unit/Services/ApmCollectorServiceTest.php
+++ b/tests/unit/Services/ApmCollectorServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use AG\ElasticApmLaravel\Agent;
+use AG\ElasticApmLaravel\Contracts\DataCollector;
+use AG\ElasticApmLaravel\Services\ApmCollectorService;
+use Codeception\Test\Unit;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
+
+class ApmCollectorServiceTest extends Unit
+{
+    private const SPAN_NAME = 'test-measure';
+
+    private $appMock;
+    private $configMock;
+    private $eventsMock;
+
+    private $collectorService;
+
+    protected function setUp(): void
+    {
+        parent::setup();
+
+        $this->appMock = Mockery::mock(Application::class);
+        $this->configMock = Mockery::mock(Config::class);
+        $this->eventsMock = Mockery::mock(Dispatcher::class);
+
+        $this->configMock->shouldReceive('get')
+            ->once()
+            ->with('elastic-apm-laravel.active')
+            ->andReturn(true);
+        
+        $this->collectorService = new ApmCollectorService(
+            $this->appMock,
+            $this->eventsMock,
+            $this->configMock
+        );
+    }
+
+    public function testStartMeasureEventWithDefaultValues()
+    {
+        $this->eventsMock->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(function ($event) {
+                $this->assertEquals(self::SPAN_NAME, $event->name);
+                $this->assertEquals('request', $event->type);
+                $this->assertNull($event->action);
+                $this->assertNull($event->label);
+                $this->assertNull($event->start_time);
+
+                return true;
+            }));
+
+        $this->collectorService->startMeasure(self::SPAN_NAME);
+    }
+
+    public function testStartMeasureEventWithValues()
+    {
+        $this->eventsMock->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(function ($event) {
+                $this->assertEquals(self::SPAN_NAME, $event->name);
+                $this->assertEquals('db.query', $event->type);
+                $this->assertEquals('SELECT', $event->action);
+                $this->assertEquals('Company SELECT', $event->label);
+                $this->assertEquals(1000.0, $event->start_time);
+
+                return true;
+            }));
+
+        $this->collectorService->startMeasure(
+            self::SPAN_NAME,
+            'db.query',
+            'SELECT',
+            'Company SELECT',
+            1000.0,
+        );
+    }
+
+    public function testStopMeasureEventWithDefaultValues()
+    {
+        $this->eventsMock->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(function ($event) {
+                $this->assertEquals(self::SPAN_NAME, $event->name);
+                $this->assertEquals([], $event->params);
+
+                return true;
+            }));
+
+        $this->collectorService->stopMeasure(self::SPAN_NAME);
+    }
+
+    public function testStopMeasureEventWithValues()
+    {
+        $this->eventsMock->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(function ($event) {
+                $this->assertEquals(self::SPAN_NAME, $event->name);
+                $this->assertEquals(['user' => 1], $event->params);
+
+                return true;
+            }));
+
+        $this->collectorService->stopMeasure(
+            self::SPAN_NAME,
+            ['user' => 1],
+        );
+    }
+
+    public function testAddCollector()
+    {
+        $agentMock = Mockery::mock(Agent::class);
+        $collectorMock = Mockery::mock(DataCollector::class);
+
+        $agentMock->shouldReceive('addCollector')
+            ->with($collectorMock);
+        
+        $this->appMock->shouldReceive('make')
+            ->with(Agent::class)
+            ->andReturn($agentMock);
+
+        $this->appMock->shouldReceive('make')
+            ->with('App\Collectors\MyCollector')
+            ->andReturn($collectorMock);
+
+        $this->collectorService->addCollector('App\Collectors\MyCollector');
+    }
+
+    public function testAddCollectorWithDisabledAgent()
+    {
+        $this->configMock->shouldReceive('get')
+            ->once()
+            ->with('elastic-apm-laravel.active')
+            ->andReturn(false);
+
+        $this->collectorService = new ApmCollectorService(
+            $this->appMock,
+            $this->eventsMock,
+            $this->configMock
+        );
+
+        $this->appMock->shouldNotReceive('make');
+
+        $this->collectorService->addCollector('App\Collectors\MyCollector');
+    }
+}

--- a/tests/unit/Services/ApmCollectorServiceTest.php
+++ b/tests/unit/Services/ApmCollectorServiceTest.php
@@ -115,13 +115,16 @@ class ApmCollectorServiceTest extends Unit
         $collectorMock = Mockery::mock(DataCollector::class);
 
         $agentMock->shouldReceive('addCollector')
+            ->once()
             ->with($collectorMock);
 
         $this->appMock->shouldReceive('make')
+            ->once()
             ->with(Agent::class)
             ->andReturn($agentMock);
 
         $this->appMock->shouldReceive('make')
+            ->once()
             ->with('App\Collectors\MyCollector')
             ->andReturn($collectorMock);
 

--- a/tests/unit/Services/ApmCollectorServiceTest.php
+++ b/tests/unit/Services/ApmCollectorServiceTest.php
@@ -30,7 +30,7 @@ class ApmCollectorServiceTest extends Unit
             ->once()
             ->with('elastic-apm-laravel.active')
             ->andReturn(true);
-        
+
         $this->collectorService = new ApmCollectorService(
             $this->appMock,
             $this->eventsMock,
@@ -116,7 +116,7 @@ class ApmCollectorServiceTest extends Unit
 
         $agentMock->shouldReceive('addCollector')
             ->with($collectorMock);
-        
+
         $this->appMock->shouldReceive('make')
             ->with(Agent::class)
             ->andReturn($agentMock);


### PR DESCRIPTION
While writing unit tests for the `TimelineCollector` class, I realized about the following:

- The class is dedicated to listening to events, not to collect _timeline_ events. For that reason, I renamed the class to `EventDataCollector`. I also added a new method to the interface to reflect that behavior.
- It wasn't clear from the docs when to register the new collector. I tried to make it easier for our users, and I exposed a method in our Facade to add custom collectors: `ApmCollector::addCollector(MyCollector::class);`. The README includes an example to create and register an event collector.

@cykirsch thoughts?

@countless-integers I removed namespaces in unit tests, not sure how useful it is for classes that are never imported. I moved all tests into a `unit` folder, and I had to update all namespaces to make it work again...