### PR TITLE
Fixes for framework events and job spans

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -37,15 +37,18 @@ class Agent extends PhilKraAgent
         $this->collectors = new Collection();
     }
 
+    public function registerInitCollectors(): void
+    {
+        // Laravel init collector
+        $this->addCollector(app(FrameworkCollector::class));
+    }
+
     public function registerCollectors(): void
     {
         if (false !== config('elastic-apm-laravel.spans.querylog.enabled')) {
             // DB Queries collector
             $this->addCollector(app(DBQueryCollector::class));
         }
-
-        // Laravel init collector
-        $this->addCollector(app(FrameworkCollector::class));
 
         // Http request collector
         if ('cli' !== php_sapi_name()) {

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -72,26 +72,17 @@ class JobCollector extends EventDataCollector implements DataCollector
      * Jobs don't have a response code like HTTP but we'll add the 200 success or 500 failure anyway
      * because it helps with filtering in Elastic.
      */
-    protected function setTransactionResult(string $transaction_name, int $result): void
-    {
-        $this->agent->getTransaction($transaction_name)->setMeta([
-            'result' => $result,
-        ]);
-    }
-
     protected function stopTransaction(string $transaction_name, int $result): void
     {
         // Stop the transaction and measure the time
-        $this->agent->stopTransaction($transaction_name);
+        $this->agent->stopTransaction($transaction_name, ['result' => $result]);
         $this->agent->collectEvents($transaction_name);
-
-        $this->setTransactionResult($transaction_name, $result);
     }
 
     protected function send(Job $job): void
     {
         try {
-            if (! ($job instanceof SyncJob)) {
+            if (!($job instanceof SyncJob)) {
                 // When using a queued driver, send/flush transaction to make room for the next job in the queue
                 // Otherwise just send when the agent destructs
                 $this->agent->send();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,6 +27,7 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->registerAgent();
+        $this->registerInitCollectors();
     }
 
     /**
@@ -84,6 +85,15 @@ class ServiceProvider extends BaseServiceProvider
     {
         $agent = $this->app->make(Agent::class);
         $agent->registerCollectors();
+    }
+
+    /**
+     * Register data collectors that require starting earlier - before boot.
+     */
+    protected function registerInitCollectors(): void
+    {
+        $agent = $this->app->make(Agent::class);
+        $agent->registerInitCollectors();
     }
 
     /**

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use AG\ElasticApmLaravel\Agent;
+use AG\ElasticApmLaravel\Collectors\JobCollector;
+use Codeception\Test\Unit;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Support\Facades\Log;
+use PhilKra\Events\Transaction;
+
+class JobCollectorTest extends Unit
+{
+    private const JOB_NAME = 'This\Is\A\Test\Job';
+    private const REQUEST_START_TIME = 1000.0;
+
+    /**
+     * @var \AG\ElasticApmLaravel\Collectors\JobCollector
+     */
+    private $collector;
+
+    private $agentMock;
+
+    protected function _before()
+    {
+        $this->app = app(Application::class);
+        $this->dispatcher = app(Dispatcher::class);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jobMock = Mockery::mock(Job::class);
+        $this->jobMock
+            ->shouldReceive('resolveName')
+            ->once()
+            ->andReturn(self::JOB_NAME);
+
+        $this->transactionMock = Mockery::mock(Transaction::class);
+
+        $this->agentMock = Mockery::mock(Agent::class);
+        $this->agentMock
+            ->shouldReceive('getRequestStartTime')
+            ->once()
+            ->andReturn(self::REQUEST_START_TIME);
+
+        $this->collector = new JobCollector($this->app, $this->agentMock);
+    }
+
+    protected function tearDown(): void
+    {
+        // JobCollector registers these listeners and we need to start fresh each for every test
+        $this->dispatcher->forget(JobProcessing::class);
+        $this->dispatcher->forget(JobProcessed::class);
+        $this->dispatcher->forget(JobFailed::class);
+        $this->dispatcher->forget(JobExceptionOccurred::class);
+    }
+
+    public function testCollectorName()
+    {
+        $this->assertEquals('job-collector', $this->collector->getName());
+    }
+
+    public function testJobProcessingListener()
+    {
+        $this->transactionMock
+            ->shouldReceive('setMeta')
+            ->once()
+            ->with(['type' => 'job']);
+        $this->agentMock
+            ->shouldReceive('startTransaction')
+            ->once()
+            ->with(self::JOB_NAME, [], self::REQUEST_START_TIME)
+            ->andReturn($this->transactionMock);
+        $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
+
+        $this->dispatcher->dispatch(new JobProcessing('test', $this->jobMock));
+    }
+
+    public function testJobProcessedListener()
+    {
+        $this->agentMock
+            ->shouldReceive('stopTransaction')
+            ->once()
+            ->with(self::JOB_NAME, ['result' => 200]);
+        $this->agentMock
+            ->shouldReceive('collectEvents')
+            ->once()
+            ->with(self::JOB_NAME);
+        $this->agentMock
+            ->shouldReceive('send')
+            ->once();
+
+        $this->dispatcher->dispatch(new JobProcessed('test', $this->jobMock));
+    }
+
+    public function testJobFailedListener()
+    {
+        $exception = new Exception('fail');
+
+        $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
+        $this->agentMock
+            ->shouldReceive('captureThrowable')
+            ->once()
+            ->with($exception, [], $this->transactionMock);
+        $this->agentMock
+            ->shouldReceive('stopTransaction')
+            ->once()
+            ->with(self::JOB_NAME, ['result' => 500]);
+        $this->agentMock
+            ->shouldReceive('collectEvents')
+            ->once()
+            ->with(self::JOB_NAME);
+        $this->agentMock
+            ->shouldReceive('send')
+            ->once();
+
+        $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, $exception));
+    }
+
+    public function testJobExceptionOccurredListener()
+    {
+        $exception = new Exception('occurred');
+
+        $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
+        $this->agentMock
+            ->shouldReceive('captureThrowable')
+            ->once()
+            ->with($exception, [], $this->transactionMock);
+        $this->agentMock
+            ->shouldReceive('stopTransaction')
+            ->once()
+            ->with(self::JOB_NAME, ['result' => 500]);
+        $this->agentMock
+            ->shouldReceive('collectEvents')
+            ->once()
+            ->with(self::JOB_NAME);
+        $this->agentMock
+            ->shouldReceive('send')
+            ->once();
+
+        $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, $exception));
+    }
+
+    public function testJobProcessedExceptionOnSend()
+    {
+        $this->agentMock
+            ->shouldReceive('stopTransaction')
+            ->once()
+            ->with(self::JOB_NAME, ['result' => 200]);
+        $this->agentMock
+            ->shouldReceive('collectEvents')
+            ->once()
+            ->with(self::JOB_NAME);
+        $this->agentMock
+            ->shouldReceive('send')
+            ->once()
+            ->andThrow(new Exception('snowball'));
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('snowball');
+
+        $this->dispatcher->dispatch(new JobProcessed('test', $this->jobMock));
+    }
+
+    public function testJobProcessedSyncDriver()
+    {
+        $this->agentMock
+            ->shouldReceive('stopTransaction')
+            ->once()
+            ->with(self::JOB_NAME, ['result' => 200]);
+        $this->agentMock
+            ->shouldReceive('collectEvents')
+            ->once()
+            ->with(self::JOB_NAME);
+        $this->agentMock
+            ->shouldNotReceive('send');
+
+        $syncJobMock = Mockery::mock(SyncJob::class);
+        $syncJobMock->shouldReceive('resolveName')
+            ->once()
+            ->andReturn(self::JOB_NAME);
+
+        $this->dispatcher->dispatch(new JobProcessed('test', $syncJobMock));
+    }
+}


### PR DESCRIPTION
Moving the `addCollector` call to the `boot` method caused the framework events to start being counted wrong because those listeners need to be registered before the Application booting and booted events, and the boot method is too late.
In addition, in my prior job testing, I was only using the `sync` driver, which is not very real-world behavior. With queued drivers like database, they process in a worker, so the agent doesn't destruct after one job and therefore events need to be sent manually after each of these jobs.