### PR TITLE
fix: use Log facade on transaction middleware

### DIFF
--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -6,8 +6,8 @@ use AG\ElasticApmLaravel\Agent;
 use Closure;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
-use Illuminate\Log\Logger;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Log;
 use PhilKra\Events\Transaction;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -27,13 +27,11 @@ class RecordTransaction
 {
     protected $agent;
     protected $config;
-    protected $log;
 
-    public function __construct(Agent $agent, Config $config, Logger $log)
+    public function __construct(Agent $agent, Config $config)
     {
         $this->agent = $agent;
         $this->config = $config;
-        $this->log = $log;
     }
 
     /**
@@ -89,7 +87,7 @@ class RecordTransaction
             $this->agent->stopTransaction($transaction_name);
             $this->agent->collectEvents($transaction_name);
         } catch (Throwable $t) {
-            $this->log->error($t->getMessage());
+            Log::error($t->getMessage());
         }
     }
 

--- a/tests/unit/Middleware/RecordTransactionTest.php
+++ b/tests/unit/Middleware/RecordTransactionTest.php
@@ -7,7 +7,7 @@ use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Log\Logger;
+use Illuminate\Support\Facades\Log;
 use PhilKra\Events\Transaction;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
@@ -41,7 +41,6 @@ class RecordTransactionTest extends Unit
     protected function _before()
     {
         $this->agent = Mockery::mock(Agent::class);
-        $this->log = Mockery::mock(Logger::class);
         $this->transaction = Mockery::mock(Transaction::class)->makePartial();
         $this->request = Request::create('/ping', 'GET');
         $this->response = Mockery::mock(Response::class)->makePartial();
@@ -58,7 +57,6 @@ class RecordTransactionTest extends Unit
         $this->middleware = new RecordTransaction(
             $this->agent,
             $this->config,
-            $this->log
         );
     }
 
@@ -174,7 +172,7 @@ class RecordTransactionTest extends Unit
             ->once()
             ->andThrow('exception', 'error message');
 
-        $this->log->shouldReceive('error')
+        Log::shouldReceive('error')
             ->once()
             ->with('error message');
 


### PR DESCRIPTION
We were injecting a class that is not available on Laravel 5.5.