### PR TITLE
fix: correct times for async jobs

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -40,7 +40,11 @@ class Agent extends PhilKraAgent
     public function registerInitCollectors(): void
     {
         // Laravel init collector
-        $this->addCollector(app(FrameworkCollector::class));
+        if ('cli' !== php_sapi_name()) {
+            // For cli executions, like queue workers, the application
+            // only starts once. It doesn't really make sense to measure it.
+            $this->addCollector(app(FrameworkCollector::class));
+        }
     }
 
     public function registerCollectors(): void

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -54,10 +54,11 @@ class JobCollector extends EventDataCollector implements DataCollector
 
     protected function startTransaction(string $transaction_name): Transaction
     {
+        $start_time = 'cli' === php_sapi_name() ? microtime(true) : $this->request_start_time;
         return $this->agent->startTransaction(
             $transaction_name,
             [],
-            $this->request_start_time
+            $start_time
         );
     }
 

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -55,6 +55,7 @@ class JobCollector extends EventDataCollector implements DataCollector
     protected function startTransaction(string $transaction_name): Transaction
     {
         $start_time = 'cli' === php_sapi_name() ? microtime(true) : $this->request_start_time;
+
         return $this->agent->startTransaction(
             $transaction_name,
             [],

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -72,7 +72,13 @@ class JobCollectorTest extends Unit
         $this->agentMock
             ->shouldReceive('startTransaction')
             ->once()
-            ->with(self::JOB_NAME, [], self::REQUEST_START_TIME)
+            ->withArgs(function ($job_name, $context, $start_time) {
+                $this->assertEquals(self::JOB_NAME, $job_name);
+                $this->assertEquals([], $context);
+                $this->assertNotNull($start_time);
+
+                return true;
+            })
             ->andReturn($this->transactionMock);
         $this->agentMock
             ->shouldReceive('getTransaction')


### PR DESCRIPTION
For jobs executed by queue workers, we are considering the `request_start_time` variable as the start of the request time, but this is not valid for processes that run in the background, like queue workers. Transaction times will grow in time:

![Screenshot 2020-03-04 at 15 09 24](https://user-images.githubusercontent.com/1712467/75887923-d695cb80-5e2a-11ea-8007-561c5a41ffde.png)

For transactions executed via cli, take the job starting time as transaction starting time, and don't measure Laravel boot times.

