### PR TITLE
Configurable filtering of transactions by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following environment variables are supported in the default configuration:
 |APM_SERVERURL      | URL to the APM intake service. |
 |APM_SECRETTOKEN    | Secret token, if required. |
 |APM_USEROUTEURI    | `true` or `false` defaults to `true`. The default behavior is to record the URL as defined in your routes configuration. Set to `false` to record the requested URL, but keep in mind that this can result in excessive unique entries in APM. |
-|APM_IGNORE_PATTERNS| Ignore specific routes by transaction name. Should be a regular expression, and will match multiple patterns via pipe `|` in the regex. Example: `"/\/health-check|^OPTIONS /"` |
+|APM_IGNORE_PATTERNS| Ignore specific routes by transaction name. Should be a regular expression, and will match multiple patterns via pipe `\|` in the regex. Example: `"/\/health-check\|^OPTIONS /"` |
 |APM_QUERYLOG       | `true` or `false` defaults to 'true'. Set to `false` to completely disable query logging, or to `auto` if you would like to use the threshold feature. |
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following environment variables are supported in the default configuration:
 |APM_SERVERURL      | URL to the APM intake service. |
 |APM_SECRETTOKEN    | Secret token, if required. |
 |APM_USEROUTEURI    | `true` or `false` defaults to `true`. The default behavior is to record the URL as defined in your routes configuration. Set to `false` to record the requested URL, but keep in mind that this can result in excessive unique entries in APM. |
+|APM_IGNORE_PATTERNS| Ignore specific routes by transaction name. Should be a regular expression, and will match multiple patterns via pipe `|` in the regex. Example: `"/\/health-check|^OPTIONS /"` |
 |APM_QUERYLOG       | `true` or `false` defaults to 'true'. Set to `false` to completely disable query logging, or to `auto` if you would like to use the threshold feature. |
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following environment variables are supported in the default configuration:
 |APM_SERVERURL      | URL to the APM intake service. |
 |APM_SECRETTOKEN    | Secret token, if required. |
 |APM_USEROUTEURI    | `true` or `false` defaults to `true`. The default behavior is to record the URL as defined in your routes configuration. Set to `false` to record the requested URL, but keep in mind that this can result in excessive unique entries in APM. |
-|APM_IGNORE_PATTERNS| Ignore specific routes by transaction name. Should be a regular expression, and will match multiple patterns via pipe `\|` in the regex. Example: `"/\/health-check\|^OPTIONS /"` |
+|APM_IGNORE_PATTERNS| Ignore specific routes or jobs by transaction name. Should be a regular expression, and will match multiple patterns via pipe `\|` in the regex. Note that 4 backslashes should be used to match a single backslash. Example: `"/\/health-check\|^OPTIONS \|Foo\\\\Bar\\\\Job/"` |
 |APM_QUERYLOG       | `true` or `false` defaults to 'true'. Set to `false` to completely disable query logging, or to `auto` if you would like to use the threshold feature. |
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |

--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -40,8 +40,10 @@ return [
     ],
 
     'transactions' => [
-        //This option will bundle transaction on the route name without variables
+        // This option will bundle transaction on the route name without variables.
         'useRouteUri' => env('APM_USEROUTEURI', true),
+        // This is a regular expression to match and filter out transactions by name. Use | in regex for multiple patterns.
+        'ignorePatterns' => env('APM_IGNORE_PATTERNS', null),
     ],
 
     'spans' => [

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -26,8 +26,8 @@ class DBQueryCollector extends EventDataCollector implements DataCollector
 
     private function onQueryExecutedEvent(QueryExecuted $query): void
     {
-        if ('auto' === config('elastic-apm-laravel.spans.querylog.enabled')) {
-            if ($query->time < config('elastic-apm-laravel.spans.querylog.threshold')) {
+        if ('auto' === $this->config->get('elastic-apm-laravel.spans.querylog.enabled')) {
+            if ($query->time < $this->config->get('elastic-apm-laravel.spans.querylog.threshold')) {
                 return;
             }
         }

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -4,6 +4,7 @@ namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -26,13 +27,17 @@ abstract class EventDataCollector implements DataCollector
     /** @var Collection */
     protected $measures;
 
+    /** @var Config */
+    protected $config;
+
     /** @var float */
     protected $request_start_time;
 
-    public function __construct(Application $app, Agent $agent)
+    public function __construct(Application $app, Agent $agent, Config $config)
     {
         $this->app = $app;
         $this->agent = $agent;
+        $this->config = $config;
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,10 +74,8 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function registerMiddleware(): void
     {
-        if ('OPTIONS' !== $this->app['request']->method()) {
-            $kernel = $this->app->make(Kernel::class);
-            $kernel->prependMiddleware(RecordTransaction::class);
-        }
+        $kernel = $this->app->make(Kernel::class);
+        $kernel->prependMiddleware(RecordTransaction::class);
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,8 +74,10 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function registerMiddleware(): void
     {
-        $kernel = $this->app->make(Kernel::class);
-        $kernel->prependMiddleware(RecordTransaction::class);
+        if ('OPTIONS' !== $this->app['request']->method()) {
+            $kernel = $this->app->make(Kernel::class);
+            $kernel->prependMiddleware(RecordTransaction::class);
+        }
     }
 
     /**

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -4,6 +4,7 @@ use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
 use Codeception\Test\Unit;
 use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Log;
 
@@ -35,6 +36,7 @@ class CustomCollectorTest extends Unit
     {
         $appMock = Mockery::mock(Application::class);
         $agentMock = Mockery::mock(Agent::class);
+        $configMock = Mockery::mock(Config::class);
 
         $agentMock->shouldReceive('getRequestStartTime')
             ->once()
@@ -44,7 +46,7 @@ class CustomCollectorTest extends Unit
             ->once()
             ->with('registerEventListeners method has been called.');
 
-        $this->collector = new CustomCollector($appMock, $agentMock);
+        $this->collector = new CustomCollector($appMock, $agentMock, $configMock);
     }
 
     public function testEmptyMeasures()

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -3,6 +3,7 @@
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\JobCollector;
 use Codeception\Test\Unit;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
@@ -18,6 +19,8 @@ use PhilKra\Exception\Transaction\UnknownTransactionException;
 class JobCollectorTest extends Unit
 {
     private const JOB_NAME = 'This\Is\A\Test\Job';
+    // Use 4 backslashes to match a single backslash: https://stackoverflow.com/a/15369828
+    private const JOB_IGNORE_PATTERN = "/\/health-check|This\\\\Is\\\\A\\\\Test\\\\Job/";
     private const REQUEST_START_TIME = 1000.0;
 
     /**
@@ -47,7 +50,9 @@ class JobCollectorTest extends Unit
             ->once()
             ->andReturn(self::REQUEST_START_TIME);
 
-        $this->collector = new JobCollector($this->app, $this->agentMock);
+        $this->configMock = Mockery::mock(Config::class);
+
+        $this->collector = new JobCollector($this->app, $this->agentMock, $this->configMock);
     }
 
     protected function tearDown(): void
@@ -59,13 +64,66 @@ class JobCollectorTest extends Unit
         $this->dispatcher->forget(JobExceptionOccurred::class);
     }
 
+    protected function patternConfigReturn($configIgnore = null): void
+    {
+        $this->configMock->shouldReceive('get')
+            ->once()
+            ->with('elastic-apm-laravel.transactions.ignorePatterns')
+            ->andReturn($configIgnore);
+    }
+
     public function testCollectorName()
     {
         $this->assertEquals('job-collector', $this->collector->getName());
     }
 
+    public function testJobProcessingListenerIgnored()
+    {
+        $this->patternConfigReturn(self::JOB_IGNORE_PATTERN);
+        $this->jobMock->shouldReceive('resolveName')->once()->andReturn(self::JOB_NAME);
+        $this->agentMock->shouldNotReceive('startTransaction');
+        $this->agentMock->shouldNotReceive('getTransaction');
+
+        $this->dispatcher->dispatch(new JobProcessing('test', $this->jobMock));
+    }
+
+    public function testJobProcessedListenerIgnored()
+    {
+        $this->patternConfigReturn(self::JOB_IGNORE_PATTERN);
+        $this->jobMock->shouldReceive('resolveName')->once()->andReturn(self::JOB_NAME);
+        $this->agentMock->shouldNotReceive('stopTransaction');
+        $this->agentMock->shouldNotReceive('collectEvents');
+        $this->agentMock->shouldNotReceive('send');
+
+        $this->dispatcher->dispatch(new JobProcessed('test', $this->jobMock));
+    }
+
+    public function testJobFailedListenerIgnored()
+    {
+        $this->patternConfigReturn(self::JOB_IGNORE_PATTERN);
+        $this->jobMock->shouldReceive('resolveName')->once()->andReturn(self::JOB_NAME);
+        $this->agentMock->shouldNotReceive('getTransaction');
+        $this->agentMock->shouldNotReceive('captureThrowable');
+        $this->agentMock->shouldNotReceive('stopTransaction');
+
+        $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, new Exception()));
+    }
+
+    public function testJobExceptionOccurredListenerIgnored()
+    {
+        $this->patternConfigReturn(self::JOB_IGNORE_PATTERN);
+        $this->jobMock->shouldReceive('resolveName')->once()->andReturn(self::JOB_NAME);
+        $this->agentMock->shouldNotReceive('getTransaction');
+        $this->agentMock->shouldNotReceive('captureThrowable');
+        $this->agentMock->shouldNotReceive('stopTransaction');
+
+        $this->dispatcher->dispatch(new JobExceptionOccurred('test', $this->jobMock, new Exception()));
+    }
+
     public function testJobProcessingListener()
     {
+        $this->patternConfigReturn();
+
         $this->jobMock
             ->shouldReceive('resolveName')
             ->once()
@@ -92,6 +150,8 @@ class JobCollectorTest extends Unit
 
     public function testJobProcessedListener()
     {
+        $this->patternConfigReturn();
+
         $this->jobMock
             ->shouldReceive('resolveName')
             ->once()
@@ -113,6 +173,8 @@ class JobCollectorTest extends Unit
 
     public function testJobFailedListener()
     {
+        $this->patternConfigReturn();
+
         $exception = new Exception('fail');
 
         $this->jobMock
@@ -145,6 +207,8 @@ class JobCollectorTest extends Unit
 
     public function testJobFailedListenerWithMissingTransaction()
     {
+        $this->patternConfigReturn();
+
         $exception = new Exception('fail');
 
         $this->jobMock
@@ -173,6 +237,8 @@ class JobCollectorTest extends Unit
 
     public function testJobExceptionOccurredListener()
     {
+        $this->patternConfigReturn();
+
         $exception = new Exception('occurred');
 
         $this->jobMock
@@ -205,6 +271,8 @@ class JobCollectorTest extends Unit
 
     public function testJobExceptionOccurredListenerWithMissingTransaction()
     {
+        $this->patternConfigReturn();
+
         $exception = new Exception('occurred');
 
         $this->jobMock
@@ -233,6 +301,8 @@ class JobCollectorTest extends Unit
 
     public function testJobProcessedExceptionOnSend()
     {
+        $this->patternConfigReturn();
+
         $this->jobMock
             ->shouldReceive('resolveName')
             ->once()
@@ -259,6 +329,8 @@ class JobCollectorTest extends Unit
 
     public function testJobProcessedSyncDriver()
     {
+        $this->patternConfigReturn();
+
         $this->agentMock
             ->shouldReceive('stopTransaction')
             ->once()


### PR DESCRIPTION
My logs are full of the error `The transaction "OPTIONS /my/api/path" is not registered.` I have not been able to figure out where the `getTransaction()` is initiated in this case. It likely has something to do with the barryvdh/laravel-cors package, which is worth supporting since that behavior is baked into Laravel 7.

I'm completely open to suggestions on a better solution, but this works well to fix the behavior I'm seeing.