### PR TITLE
Switch to Events\Dispatcher interface to support alternate / mock event dispatchers

### DIFF
--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -6,7 +6,7 @@ use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Events\StartMeasuring;
 use AG\ElasticApmLaravel\Events\StopMeasuring;
 use Illuminate\Config\Repository as Config;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use PhilKra\Events\Transaction;
 use Throwable;


### PR DESCRIPTION
I ran into an issue with running an integration test that verified events using Laravel's [Event::fake()](https://laravel.com/docs/7.x/mocking#event-fake).  Because `Event::fake()` replaces `Illuminate\Events\Dispatcher` with `\Illuminate\Support\Testing\Fakes\EventFake`, I was receiving the following error:
`1) mytest.php::test_a_thing
  TypeError: Argument 2 passed to AG\ElasticApmLaravel\Services\ApmCollectorService::__construct() must be an instance of Illuminate\Events\Dispatcher, instance of Illuminate\Support\Testing\Fakes\EventFake given`

By switching to the Contract, the CollectorService will be able to operate with both `Illuminate\Events\Dispatcher` (which Laravel binds by default) as well as the `EventFake`.