### PR TITLE
fix: remove trailing comma from function call

### DIFF
--- a/src/Collectors/SpanCollector.php
+++ b/src/Collectors/SpanCollector.php
@@ -24,7 +24,7 @@ class SpanCollector extends EventDataCollector implements DataCollector
                 $event->type,
                 $event->action,
                 $event->label,
-                $event->start_time,
+                $event->start_time
             );
         });
 


### PR DESCRIPTION
Closes #54

triggers an error in php <7.3