### PR TITLE
fix: create spans as synchronous events

### DIFF
--- a/src/Events/LazySpan.php
+++ b/src/Events/LazySpan.php
@@ -158,7 +158,7 @@ class LazySpan extends TraceableEvent implements JsonSerializable
                 'duration' => $this->duration,
                 'name' => Encoding::keywordField($this->getName()),
                 'stacktrace' => $this->stacktrace,
-                'sync' => false,
+                'sync' => true,
                 'timestamp' => $this->timestamp,
             ],
         ];

--- a/tests/unit/Events/LazySpanTest.php
+++ b/tests/unit/Events/LazySpanTest.php
@@ -111,7 +111,7 @@ class LazySpanTest extends Unit
         $this->assertEquals(0, $lazy_span_decoded->duration);
         $this->assertEquals('lazy span', $lazy_span_decoded->name);
         $this->assertEquals([], $lazy_span_decoded->stacktrace);
-        $this->assertFalse($lazy_span_decoded->sync);
+        $this->assertTrue($lazy_span_decoded->sync);
         $this->assertIsNumeric($lazy_span_decoded->timestamp);
     }
 }


### PR DESCRIPTION
We are creating spans as asynchronous events, when in reality all of them are synchronous. I changed the default value to `true`.

<img width="313" alt="Screenshot 2020-07-19 at 09 27 00" src="https://user-images.githubusercontent.com/1712467/87869721-2de3a500-c9a2-11ea-8d3c-6a24c722d6a1.png">
