### PR TITLE
fix: make sure transaction object exists before sending error events

### DIFF
--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -47,11 +47,11 @@ class JobCollector extends EventDataCollector implements DataCollector
             $transaction_name = $this->getTransactionName($event);
             if ($transaction_name) {
                 $transaction = $this->getTransaction($transaction_name);
-                $this->agent->captureThrowable($event->exception, [], $transaction);
                 if ($transaction) {
+                    $this->agent->captureThrowable($event->exception, [], $transaction);
                     $this->stopTransaction($transaction_name, 500);
+                    $this->send($event->job);
                 }
-                $this->send($event->job);
             }
         });
 
@@ -59,11 +59,11 @@ class JobCollector extends EventDataCollector implements DataCollector
             $transaction_name = $this->getTransactionName($event);
             if ($transaction_name) {
                 $transaction = $this->getTransaction($transaction_name);
-                $this->agent->captureThrowable($event->exception, [], $transaction);
                 if ($transaction) {
+                    $this->agent->captureThrowable($event->exception, [], $transaction);
                     $this->stopTransaction($transaction_name, 500);
+                    $this->send($event->job);
                 }
-                $this->send($event->job);
             }
         });
     }

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -221,16 +221,13 @@ class JobCollectorTest extends Unit
             ->with(self::JOB_NAME)
             ->andThrow(new UnknownTransactionException());
         $this->agentMock
-            ->shouldReceive('captureThrowable')
-            ->once()
-            ->with($exception, [], null);
+            ->shouldNotReceive('captureThrowable');
         $this->agentMock
             ->shouldNotReceive('stopTransaction');
         $this->agentMock
             ->shouldNotReceive('collectEvents');
         $this->agentMock
-            ->shouldReceive('send')
-            ->once();
+            ->shouldNotReceive('send');
 
         $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, $exception));
     }
@@ -285,16 +282,13 @@ class JobCollectorTest extends Unit
             ->with(self::JOB_NAME)
             ->andThrow(new UnknownTransactionException());
         $this->agentMock
-            ->shouldReceive('captureThrowable')
-            ->once()
-            ->with($exception, [], null);
+            ->shouldNotReceive('captureThrowable');
         $this->agentMock
             ->shouldNotReceive('stopTransaction');
         $this->agentMock
             ->shouldNotReceive('collectEvents');
         $this->agentMock
-            ->shouldReceive('send')
-            ->once();
+            ->shouldNotReceive('send');
 
         $this->dispatcher->dispatch(new JobExceptionOccurred('test', $this->jobMock, $exception));
     }


### PR DESCRIPTION
I've noticed that we're making 2 api requests with events to APM and the second one lacks transaction data (but the transaction name is set). This raises an exception during handling an exception, so chaos ensues. From what I understand from the [documentation](https://www.elastic.co/guide/en/apm/server/current/error-api.html), transaction data or id is required, so there's no reason to send requests if it's `null`. 