### PR TITLE
fix: double job error handling

### DIFF
--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -5,7 +5,6 @@ namespace AG\ElasticApmLaravel\Collectors;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Contracts\Queue\Job;
-use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -54,18 +54,6 @@ class JobCollector extends EventDataCollector implements DataCollector
                 }
             }
         });
-
-        $this->app->events->listen(JobExceptionOccurred::class, function (JobExceptionOccurred $event) {
-            $transaction_name = $this->getTransactionName($event);
-            if ($transaction_name) {
-                $transaction = $this->getTransaction($transaction_name);
-                if ($transaction) {
-                    $this->agent->captureThrowable($event->exception, [], $transaction);
-                    $this->stopTransaction($transaction_name, 500);
-                    $this->send($event->job);
-                }
-            }
-        });
     }
 
     protected function getTransaction(string $transaction_name): ?Transaction

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -109,17 +109,6 @@ class JobCollectorTest extends Unit
         $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, new Exception()));
     }
 
-    public function testJobExceptionOccurredListenerIgnored()
-    {
-        $this->patternConfigReturn(self::JOB_IGNORE_PATTERN);
-        $this->jobMock->shouldReceive('resolveName')->once()->andReturn(self::JOB_NAME);
-        $this->agentMock->shouldNotReceive('getTransaction');
-        $this->agentMock->shouldNotReceive('captureThrowable');
-        $this->agentMock->shouldNotReceive('stopTransaction');
-
-        $this->dispatcher->dispatch(new JobExceptionOccurred('test', $this->jobMock, new Exception()));
-    }
-
     public function testJobProcessingListener()
     {
         $this->patternConfigReturn();
@@ -230,67 +219,6 @@ class JobCollectorTest extends Unit
             ->shouldNotReceive('send');
 
         $this->dispatcher->dispatch(new JobFailed('test', $this->jobMock, $exception));
-    }
-
-    public function testJobExceptionOccurredListener()
-    {
-        $this->patternConfigReturn();
-
-        $exception = new Exception('occurred');
-
-        $this->jobMock
-            ->shouldReceive('resolveName')
-            ->once()
-            ->andReturn(self::JOB_NAME);
-        $this->agentMock
-            ->shouldReceive('getTransaction')
-            ->once()
-            ->with(self::JOB_NAME)
-            ->andReturn($this->transactionMock);
-        $this->agentMock
-            ->shouldReceive('captureThrowable')
-            ->once()
-            ->with($exception, [], $this->transactionMock);
-        $this->agentMock
-            ->shouldReceive('stopTransaction')
-            ->once()
-            ->with(self::JOB_NAME, ['result' => 500]);
-        $this->agentMock
-            ->shouldReceive('collectEvents')
-            ->once()
-            ->with(self::JOB_NAME);
-        $this->agentMock
-            ->shouldReceive('send')
-            ->once();
-
-        $this->dispatcher->dispatch(new JobExceptionOccurred('test', $this->jobMock, $exception));
-    }
-
-    public function testJobExceptionOccurredListenerWithMissingTransaction()
-    {
-        $this->patternConfigReturn();
-
-        $exception = new Exception('occurred');
-
-        $this->jobMock
-            ->shouldReceive('resolveName')
-            ->once()
-            ->andReturn(self::JOB_NAME);
-        $this->agentMock
-            ->shouldReceive('getTransaction')
-            ->once()
-            ->with(self::JOB_NAME)
-            ->andThrow(new UnknownTransactionException());
-        $this->agentMock
-            ->shouldNotReceive('captureThrowable');
-        $this->agentMock
-            ->shouldNotReceive('stopTransaction');
-        $this->agentMock
-            ->shouldNotReceive('collectEvents');
-        $this->agentMock
-            ->shouldNotReceive('send');
-
-        $this->dispatcher->dispatch(new JobExceptionOccurred('test', $this->jobMock, $exception));
     }
 
     public function testJobProcessedExceptionOnSend()


### PR DESCRIPTION
When processing errors in queued jobs, we were listening to both `JobExceptionOccurred` and `JobFailed` events. This was causing errors to not be correctly registered in APM, as we were trying to send the same transaction/error twice. Listening to `JobFailed` should be enough.