### PR TITLE
chore: prevent duplicated transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,23 @@ Please adhere to [PSR-2](https://github.com/php-fig/fig-standards/blob/master/ac
 ```bash
 php ./vendor/bin/php-cs-fixer fix --config .php_cs
 ```
+
+### Integrate with a running application
+
+To be able to test your changes with a locally running application, use Composer's functionality to require packages from local paths. On your project, add a local repository, just make sure the path to `elastic-apm-laravel` folder is correct:
+
+```bash
+composer config repositories.local '{"type": "path", "url": "../elastic-apm-laravel"}' --file composer.json
+```
+
+Then install the package from the source:
+
+```bash
+composer require arkaitzgarro/elastic-apm-laravel:@dev --prefer-source
+```
+
+You should see a message indicating that the package has been installed as symlink:
+
+```bash
+- Installing arkaitzgarro/elastic-apm-laravel (dev-chore/branch-name): Symlinking from ../elastic-apm-laravel
+```

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -130,9 +130,9 @@ class JobCollectorTest extends Unit
             ->andReturn($this->transactionMock);
         $this->agentMock
             ->shouldReceive('getTransaction')
-            ->once()
+            ->twice()
             ->with(self::JOB_NAME)
-            ->andReturn($this->transactionMock);
+            ->andReturn(null, $this->transactionMock);
 
         $this->dispatcher->dispatch(new JobProcessing('test', $this->jobMock));
     }
@@ -145,6 +145,11 @@ class JobCollectorTest extends Unit
             ->shouldReceive('resolveName')
             ->once()
             ->andReturn(self::JOB_NAME);
+        $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
         $this->agentMock
             ->shouldReceive('stopTransaction')
             ->once()
@@ -230,6 +235,11 @@ class JobCollectorTest extends Unit
             ->once()
             ->andReturn(self::JOB_NAME);
         $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
+        $this->agentMock
             ->shouldReceive('stopTransaction')
             ->once()
             ->with(self::JOB_NAME, ['result' => 200]);
@@ -253,6 +263,11 @@ class JobCollectorTest extends Unit
     {
         $this->patternConfigReturn();
 
+        $this->agentMock
+            ->shouldReceive('getTransaction')
+            ->once()
+            ->with(self::JOB_NAME)
+            ->andReturn($this->transactionMock);
         $this->agentMock
             ->shouldReceive('stopTransaction')
             ->once()


### PR DESCRIPTION
Somehow, some job transactions can be started within the same process with the same name, something not allowed by the underlying agent. We don't really know the reason, but it throws an exception and we want to prevent that.