### PR TITLE
feat: add metadata to Job events

### DIFF
--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -117,6 +117,26 @@ class JobCollectorTest extends Unit
             ->shouldReceive('resolveName')
             ->once()
             ->andReturn(self::JOB_NAME);
+        $this->jobMock
+            ->shouldReceive('getJobId')
+            ->once()
+            ->andReturn('job_id');
+        $this->jobMock
+            ->shouldReceive('maxTries')
+            ->once()
+            ->andReturn(3);
+        $this->jobMock
+            ->shouldReceive('attempts')
+            ->once()
+            ->andReturn(1);
+        $this->jobMock
+            ->shouldReceive('getConnectionName')
+            ->once()
+            ->andReturn('sync');
+        $this->jobMock
+            ->shouldReceive('getQueue')
+            ->once()
+            ->andReturn('queue');
         $this->agentMock
             ->shouldReceive('startTransaction')
             ->once()
@@ -130,9 +150,9 @@ class JobCollectorTest extends Unit
             ->andReturn($this->transactionMock);
         $this->agentMock
             ->shouldReceive('getTransaction')
-            ->twice()
+            ->times(3)
             ->with(self::JOB_NAME)
-            ->andReturn(null, $this->transactionMock);
+            ->andReturn(null, $this->transactionMock, $this->transactionMock);
 
         $this->dispatcher->dispatch(new JobProcessing('test', $this->jobMock));
     }


### PR DESCRIPTION
Add Job metadata to APM via custom context:

- `job_id`: the job identifier.
- `attempts`: the number of times the job has been attempted.
- `max_tries`: the number of times to attempt a job.
- `connection_name`: the name of the connection the job belongs to.
- `queue_name`: name of the queue the job belongs to.

Important: Custom metadata adds non-indexed, custom contextual information to transactions and errors. Non-indexed means the data is not searchable or aggregatable in Elasticsearch, and you cannot build dashboards on top of the data. This also means you don’t have to worry about mapping explosions, as these fields are not added to the mapping.

https://www.elastic.co/guide/en/apm/get-started/current/metadata.html#custom-fields