### PR TITLE
Chore/migrate php agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",
         "jasny/dbquery-mysql": "^2.0",
-        "nipwaayoni/elastic-apm-php-agent": "^7.2"
+        "nipwaayoni/elastic-apm-php-agent": "^7.3"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74b66ab59b15e1b0093cbaa7d84ccfde",
+    "content-hash": "a749594ca9021d523316c5b4d74e8a63",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -736,16 +736,16 @@
         },
         {
             "name": "nipwaayoni/elastic-apm-php-agent",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nipwaayoni/elastic-apm-php-agent.git",
-                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee"
+                "reference": "4707a43e7f80f846990721a5a704a3da85425901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
-                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
+                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/4707a43e7f80f846990721a5a704a3da85425901",
+                "reference": "4707a43e7f80f846990721a5a704a3da85425901",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +785,7 @@
                 }
             ],
             "description": "A php agent for Elastic APM v2 Intake API",
-            "time": "2020-07-19T00:50:48+00:00"
+            "time": "2020-09-06T17:38:05+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -5541,5 +5541,6 @@
     "platform": {
         "php": ">=7.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -29,11 +29,12 @@ class Agent extends NipwaayoniAgent
     protected $collectors;
     protected $request_start_time;
 
-    public function __construct(array $config, float $request_start_time)
+    /*
+     * This method will be called by the parent's final constructor
+     */
+    protected function initialize(): void
     {
-        parent::__construct($config);
-
-        $this->request_start_time = $request_start_time;
+        $this->request_start_time = microtime(true);
         $this->collectors = new Collection();
     }
 
@@ -96,6 +97,11 @@ class Agent extends NipwaayoniAgent
                 $this->putEvent($event);
             });
         });
+    }
+
+    public function setRequestStartTime(float $startTime): void
+    {
+        $this->request_start_time = $startTime;
     }
 
     public function getRequestStartTime(): float


### PR DESCRIPTION
This uses the new release of the `nipwaayoni/elastic-apm-php-agent` package to address some issues with extending the `Agent` class. 

I had to make some changes to how the `AG\ElasticApmLaravel\Agent`, but I hope the impact is limited to the service provider. I don't expect anyone to be creating an agent themselves.

The ServiceProvider has been updated to us the provided `AgentBuilder` to construct the agent object. While this is a few more lines of code, the `Nipwaayoni\Agent` had become far too complicated to create in a flexible way. The `Nipwaayoni\AgentBuilder` enables flexibility while hiding the complexity of the creation.

While implementing this, I did find a Laravel register/boot order issue which I would like to address in a separate PR before this is all merged for a release.