### PR TITLE
chore: migrate current Elastic PHP agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",
         "jasny/dbquery-mysql": "^2.0",
-        "nipwaayoni/elastic-apm-php-agent": "^7.4"
+        "nipwaayoni/elastic-apm-php-agent": "^7.4",
+        "http-interop/http-factory-guzzle": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",
         "jasny/dbquery-mysql": "^2.0",
-        "nipwaayoni/elastic-apm-php-agent": "^7.2"
+        "nipwaayoni/elastic-apm-php-agent": "^7.3"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",
         "jasny/dbquery-mysql": "^2.0",
-        "nipwaayoni/elastic-apm-php-agent": "^7.3"
+        "nipwaayoni/elastic-apm-php-agent": "^7.4"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,6 @@
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "codeception/mockery-module": "^0.4.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Nipwaayoni/elastic-apm-php-agent"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "AG\\ElasticApmLaravel\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "illuminate/http": "^5.5|^6|^7",
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",
-        "philkra/elastic-apm-php-agent": "dev-master",
-        "jasny/dbquery-mysql": "^2.0"
+        "jasny/dbquery-mysql": "^2.0",
+        "nipwaayoni/elastic-apm-php-agent": "^7.2"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",
@@ -33,7 +33,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/philkra/elastic-apm-php-agent"
+            "url": "https://github.com/Nipwaayoni/elastic-apm-php-agent"
         }
     ],
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f1dd6ac473eaede48231df321d1fcc7",
+    "content-hash": "fbfc852c8e05edf0947f144eeb388bc7",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -238,6 +238,245 @@
                 "parser"
             ],
             "time": "2019-12-30T22:54:17+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.11"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2020-04-18T10:38:46+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "http-interop/http-factory-guzzle",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-factory-guzzle.git",
+                "reference": "34861658efb9899a6618cef03de46e2a52c80fc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-factory-guzzle/zipball/34861658efb9899a6618cef03de46e2a52c80fc0",
+                "reference": "34861658efb9899a6618cef03de46e2a52c80fc0",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^1.4.2",
+                "psr/http-factory": "^1.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.5",
+                "phpunit/phpunit": "^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Factory\\Guzzle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "An HTTP Factory using Guzzle PSR7",
+            "keywords": [
+                "factory",
+                "http",
+                "psr-17",
+                "psr-7"
+            ],
+            "time": "2018-07-31T19:32:56+00:00"
         },
         {
             "name": "jasny/dbquery-mysql",
@@ -896,6 +1135,180 @@
                 "psr7"
             ],
             "time": "2020-07-13T15:44:45+00:00"
+        },
+        {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "6074a4b1f4d5c21061b70bab3b8ad484282fe31f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/6074a4b1f4d5c21061b70bab3b8ad484282fe31f",
+                "reference": "6074a4b1f4d5c21061b70bab3b8ad484282fe31f",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": "^7.1",
+                "php-http/httplug": "^2.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0",
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^2.0",
+                "phpunit/phpunit": "^7.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "time": "2018-12-16T14:44:03+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1",
+                "phpspec/phpspec": "^5.1 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "time": "2020-07-13T15:43:23+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
+                "phpspec/phpspec": "^5.1.2 || ^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2020-07-07T09:29:14+00:00"
         },
         {
             "name": "psr/container",
@@ -3549,77 +3962,6 @@
             "time": "2020-06-27T23:57:46+00:00"
         },
         {
-            "name": "guzzlehttp/psr7",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
-            },
-            "suggest": {
-                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "time": "2019-07-01T23:21:34+00:00"
-        },
-        {
             "name": "hamcrest/hamcrest-php",
             "version": "v2.0.0",
             "source": {
@@ -5592,6 +5934,5 @@
     "platform": {
         "php": ">=7.3"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74b66ab59b15e1b0093cbaa7d84ccfde",
+    "content-hash": "a749594ca9021d523316c5b4d74e8a63",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -736,16 +736,16 @@
         },
         {
             "name": "nipwaayoni/elastic-apm-php-agent",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nipwaayoni/elastic-apm-php-agent.git",
-                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee"
+                "reference": "4707a43e7f80f846990721a5a704a3da85425901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
-                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
+                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/4707a43e7f80f846990721a5a704a3da85425901",
+                "reference": "4707a43e7f80f846990721a5a704a3da85425901",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +785,7 @@
                 }
             ],
             "description": "A php agent for Elastic APM v2 Intake API",
-            "time": "2020-07-19T00:50:48+00:00"
+            "time": "2020-09-06T17:38:05+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -5592,5 +5592,6 @@
     "platform": {
         "php": ">=7.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a749594ca9021d523316c5b4d74e8a63",
+    "content-hash": "7f1dd6ac473eaede48231df321d1fcc7",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -736,16 +736,16 @@
         },
         {
             "name": "nipwaayoni/elastic-apm-php-agent",
-            "version": "v7.3.0",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nipwaayoni/elastic-apm-php-agent.git",
-                "reference": "4707a43e7f80f846990721a5a704a3da85425901"
+                "reference": "2361c60d1149f591e0599335a2cb9eeb1f992070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/4707a43e7f80f846990721a5a704a3da85425901",
-                "reference": "4707a43e7f80f846990721a5a704a3da85425901",
+                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/2361c60d1149f591e0599335a2cb9eeb1f992070",
+                "reference": "2361c60d1149f591e0599335a2cb9eeb1f992070",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +785,7 @@
                 }
             ],
             "description": "A php agent for Elastic APM v2 Intake API",
-            "time": "2020-09-06T17:38:05+00:00"
+            "time": "2020-09-12T10:58:04+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/composer.lock
+++ b/composer.lock
@@ -2571,7 +2571,7 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
+            ]
         },
         {
             "name": "symfony/polyfill-php56",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f065a33e5c6d1ff4ff761db282129db",
+    "content-hash": "74b66ab59b15e1b0093cbaa7d84ccfde",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -133,20 +133,6 @@
                 "parser",
                 "php"
             ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-25T17:44:05+00:00"
         },
         {
@@ -252,195 +238,6 @@
                 "parser"
             ],
             "time": "2019-12-30T22:54:17+00:00"
-        },
-        {
-            "name": "guzzlehttp/guzzle",
-            "version": "6.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/43ece0e75098b7ecd8d13918293029e555a50f82",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.1"
-            },
-            "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2019-12-23T11:57:10+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "time": "2016-12-20T10:07:11+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
-            },
-            "suggest": {
-                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "jasny/dbquery-mysql",
@@ -751,12 +548,6 @@
                 "sftp",
                 "storage"
             ],
-            "funding": [
-                {
-                    "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
-                }
-            ],
             "time": "2020-03-17T18:58:12+00:00"
         },
         {
@@ -944,6 +735,59 @@
             "time": "2019-10-14T05:51:36+00:00"
         },
         {
+            "name": "nipwaayoni/elastic-apm-php-agent",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nipwaayoni/elastic-apm-php-agent.git",
+                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nipwaayoni/elastic-apm-php-agent/zipball/cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
+                "reference": "cf8a8bd0f860ec472eba45d2bb64f1ff28f7dcee",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": ">= 7.1",
+                "php-http/discovery": "^1.7",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "ralouphie/getallheaders": "2.*|3.*"
+            },
+            "require-dev": {
+                "http-interop/http-factory-guzzle": "^1.0",
+                "justinrainbow/json-schema": "^5.2",
+                "php-http/guzzle6-adapter": "^2.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "suggest": {
+                "http-interop/http-factory-guzzle": "PSR-17 compatible factories for usage with PSR-18",
+                "php-http/guzzle6-adapter": "PSR-18 compatible Guzzle6 adapter"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nipwaayoni\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dirk Tepe",
+                    "email": "dstepe@gmail.com",
+                    "homepage": "https://github.com/dstepe"
+                }
+            ],
+            "description": "A php agent for Elastic APM v2 Intake API",
+            "time": "2020-07-19T00:50:48+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v9.99.99",
             "source": {
@@ -989,68 +833,69 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
-            "name": "philkra/elastic-apm-php-agent",
-            "version": "dev-master",
+            "name": "php-http/discovery",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/philkra/elastic-apm-php-agent.git",
-                "reference": "e2623d7aa7c97ae5f2ec1088e715b27add7cb163"
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "64a18cc891957e05d91910b3c717d6bd11fbede9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/philkra/elastic-apm-php-agent/zipball/e2623d7aa7c97ae5f2ec1088e715b27add7cb163",
-                "reference": "e2623d7aa7c97ae5f2ec1088e715b27add7cb163",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/64a18cc891957e05d91910b3c717d6bd11fbede9",
+                "reference": "64a18cc891957e05d91910b3c717d6bd11fbede9",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "guzzlehttp/guzzle": "6.*",
-                "php": ">= 7.1",
-                "ralouphie/getallheaders": "3.*"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "7.*"
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1",
+                "puli/composer-plugin": "1.0.0-beta10"
             },
             "suggest": {
-                "ext-xdebug": "Required for processing of request headers"
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "PhilKra\\": "src/"
+                    "Http\\Discovery\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "PhilKra\\Tests\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Philip Krauss",
-                    "email": "philip@philipkrauss.at",
-                    "homepage": "https://github.com/philkra"
-                },
-                {
-                    "name": "George Boot",
-                    "email": "george@entryninja.com"
-                },
-                {
-                    "name": "Mohamed Al Ashaal",
-                    "email": "mohamed.alashaal@speakol.com",
-                    "homepage": "https://github.com/speakol-ads"
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
                 }
             ],
-            "description": "A php agent for Elastic APM v2 Intake API",
-            "support": {
-                "source": "https://github.com/philkra/elastic-apm-php-agent/tree/master",
-                "issues": "https://github.com/philkra/elastic-apm-php-agent/issues"
-            },
-            "time": "2020-02-11T10:48:55+00:00"
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2020-07-13T15:44:45+00:00"
         },
         {
             "name": "psr/container",
@@ -1100,6 +945,107 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1505,21 +1451,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-06T08:57:31+00:00"
+            "time": "2020-05-30T18:58:05+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -1572,20 +1504,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -1642,21 +1560,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-16T09:41:49+00:00"
+            "time": "2020-05-22T18:25:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1740,7 +1644,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-18T17:59:13+00:00"
+            "time": "2020-05-20T08:37:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1865,20 +1769,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
@@ -1933,20 +1823,6 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-23T12:14:52+00:00"
         },
         {
@@ -2037,20 +1913,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T06:25:13+00:00"
         },
         {
@@ -2113,21 +1975,7 @@
                 "polyfill",
                 "portable"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
@@ -2185,20 +2033,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-09T19:04:49+00:00"
         },
@@ -2261,20 +2095,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-09T19:04:49+00:00"
         },
@@ -2339,21 +2159,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -2408,20 +2213,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-09T19:04:49+00:00"
         },
@@ -2486,20 +2277,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -2555,20 +2332,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -2621,20 +2384,6 @@
                 "polyfill",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-02T11:55:35+00:00"
         },
         {
@@ -2684,20 +2433,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-23T17:05:51+00:00"
         },
         {
@@ -2773,20 +2508,6 @@
                 "routing",
                 "uri",
                 "url"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-25T12:02:26+00:00"
         },
@@ -2990,20 +2711,6 @@
                 "debug",
                 "dump"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-17T22:27:36+00:00"
         },
         {
@@ -3109,12 +2816,6 @@
                 "dotenv",
                 "env",
                 "environment"
-            ],
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-27T23:16:19+00:00"
         }
@@ -3262,13 +2963,7 @@
                 "functional testing",
                 "unit testing"
             ],
-            "funding": [
-                {
-                    "url": "https://opencollective.com/codeception",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2020-08-28T06:37:06+00:00"
+            "time": "2020-06-07T16:31:51+00:00"
         },
         {
             "name": "codeception/lib-asserts",
@@ -3594,20 +3289,6 @@
                 "Xdebug",
                 "performance"
             ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-06-04T11:16:35+00:00"
         },
         {
@@ -3774,20 +3455,6 @@
                 "constructor",
                 "instantiate"
             ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-29T17:27:14+00:00"
         },
         {
@@ -3879,13 +3546,78 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "funding": [
+            "time": "2020-06-27T23:57:46+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
                 {
-                    "url": "https://github.com/keradus",
-                    "type": "github"
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "time": "2020-06-27T23:57:46+00:00"
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -4750,17 +4482,7 @@
                 "testing",
                 "xunit"
             ],
-            "funding": [
-                {
-                    "url": "https://phpunit.de/donate.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-06-22T07:06:58+00:00"
+            "time": "2020-05-22T13:51:52+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5421,20 +5143,6 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-27T08:34:37+00:00"
         },
         {
@@ -5485,20 +5193,6 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-30T20:35:19+00:00"
         },
         {
@@ -5554,20 +5248,6 @@
                 "config",
                 "configuration",
                 "options"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-23T13:08:13+00:00"
         },
@@ -5635,20 +5315,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -5711,21 +5377,7 @@
                 "interoperability",
                 "standards"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -5775,20 +5427,6 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -5848,20 +5486,6 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-20T08:37:50+00:00"
         },
         {
@@ -5962,14 +5586,11 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "philkra/elastic-apm-php-agent": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.3"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -2,8 +2,8 @@
 
 namespace AG\ElasticApmLaravel;
 
-use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Illuminate\Support\Collection;

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -2,17 +2,18 @@
 
 namespace AG\ElasticApmLaravel;
 
-use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
-use AG\ElasticApmLaravel\Collectors\FrameworkCollector;
-use AG\ElasticApmLaravel\Collectors\HttpRequestCollector;
-use AG\ElasticApmLaravel\Collectors\JobCollector;
-use AG\ElasticApmLaravel\Collectors\SpanCollector;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Illuminate\Support\Collection;
-use PhilKra\Events\Metadata;
-use PhilKra\Agent as NipwaayoniAgent;
+use Nipwaayoni\Agent as NipwaayoniAgent;
+use Nipwaayoni\Config;
+use Nipwaayoni\Contexts\ContextCollection;
+use Nipwaayoni\Events\EventFactoryInterface;
+use Nipwaayoni\Events\Metadata;
+use Nipwaayoni\Middleware\Connector;
+use Nipwaayoni\Stores\TransactionsStore;
 
 /**
  * The Elastic APM agent sends performance metrics and error logs to the APM Server.
@@ -31,46 +32,24 @@ class Agent extends NipwaayoniAgent
     protected $collectors;
     protected $request_start_time;
 
-    /*
-     * This method will be called by the parent's final constructor
-     */
-    protected function initialize(): void
-    {
-        $this->request_start_time = microtime(true);
+    public function __construct(
+        Config $config,
+        ContextCollection $sharedContext,
+        Connector $connector,
+        EventFactoryInterface $eventFactory,
+        TransactionsStore $transactionsStore,
+        RequestStartTime $startTime
+    ) {
+        parent::__construct($config, $sharedContext, $connector, $eventFactory, $transactionsStore);
+
+        $this->request_start_time = $startTime->microseconds();
         $this->collectors = new Collection();
-    }
-
-    public function registerInitCollectors(): void
-    {
-        // Laravel init collector
-        if ('cli' !== php_sapi_name()) {
-            // For cli executions, like queue workers, the application
-            // only starts once. It doesn't really make sense to measure it.
-            $this->addCollector(app(FrameworkCollector::class));
-        }
-    }
-
-    public function registerCollectors(): void
-    {
-        if (false !== config('elastic-apm-laravel.spans.querylog.enabled')) {
-            // DB Queries collector
-            $this->addCollector(app(DBQueryCollector::class));
-        }
-
-        // Http request collector
-        if ('cli' !== php_sapi_name()) {
-            $this->addCollector(app(HttpRequestCollector::class));
-        }
-
-        // Job collector
-        $this->addCollector(app(JobCollector::class));
-
-        // Collector for manual measurements throughout the app
-        $this->addCollector(app(SpanCollector::class));
     }
 
     public function addCollector(DataCollector $collector): void
     {
+        $collector->useAgent($this);
+
         $this->collectors->put(
             $collector->getName(),
             $collector
@@ -99,11 +78,6 @@ class Agent extends NipwaayoniAgent
                 $this->putEvent($event);
             });
         });
-    }
-
-    public function setRequestStartTime(float $startTime): void
-    {
-        $this->request_start_time = $startTime;
     }
 
     public function getRequestStartTime(): float

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -31,11 +31,12 @@ class Agent extends NipwaayoniAgent
     protected $collectors;
     protected $request_start_time;
 
-    public function __construct(array $config, float $request_start_time)
+    /*
+     * This method will be called by the parent's final constructor
+     */
+    protected function initialize(): void
     {
-        parent::__construct($config);
-
-        $this->request_start_time = $request_start_time;
+        $this->request_start_time = microtime(true);
         $this->collectors = new Collection();
     }
 
@@ -98,6 +99,11 @@ class Agent extends NipwaayoniAgent
                 $this->putEvent($event);
             });
         });
+    }
+
+    public function setRequestStartTime(float $startTime): void
+    {
+        $this->request_start_time = $startTime;
     }
 
     public function getRequestStartTime(): float

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -11,8 +11,8 @@ use AG\ElasticApmLaravel\Collectors\SpanCollector;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Illuminate\Support\Collection;
-use PhilKra\Agent as PhilKraAgent;
 use PhilKra\Events\Metadata;
+use PhilKra\Agent as NipwaayoniAgent;
 
 /**
  * The Elastic APM agent sends performance metrics and error logs to the APM Server.
@@ -26,7 +26,7 @@ use PhilKra\Events\Metadata;
  * and sends them to an Elasticsearch cluster. You can then use the APM app
  * in Kibana to gain insight into latency issues and error culprits within your application.
  */
-class Agent extends PhilKraAgent
+class Agent extends NipwaayoniAgent
 {
     protected $collectors;
     protected $request_start_time;
@@ -120,7 +120,7 @@ class Agent extends PhilKraAgent
          * worker processes. A future release of the Agent package should handle event
          * collection better and remove the need for this.
          */
-        $this->putEvent(new Metadata([], $this->getConfig()));
+        $this->putEvent(new Metadata([], $this->getConfig(), $this->agentMetadata()));
 
         return $sent;
     }

--- a/src/AgentBuilder.php
+++ b/src/AgentBuilder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AG\ElasticApmLaravel;
+
+use AG\ElasticApmLaravel\Collectors\EventDataCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
+use Illuminate\Support\Collection;
+use Nipwaayoni\AgentBuilder as NipwaayoniAgentBuilder;
+use Nipwaayoni\ApmAgent;
+use Nipwaayoni\Config;
+use Nipwaayoni\Contexts\ContextCollection;
+use Nipwaayoni\Events\EventFactoryInterface;
+use Nipwaayoni\Middleware\Connector;
+use Nipwaayoni\Stores\TransactionsStore;
+
+class AgentBuilder extends NipwaayoniAgentBuilder
+{
+    /** @var RequestStartTime */
+    private $startTime;
+
+    /** @var Collection */
+    private $collectors;
+
+    public function withRequestStartTime(RequestStartTime $startTime): self
+    {
+        $this->startTime = $startTime;
+
+        return $this;
+    }
+
+    public function withEventCollectors(Collection $collectors): self
+    {
+        $this->collectors = $collectors;
+
+        return $this;
+    }
+
+    protected function newAgent(
+        Config $config,
+        ContextCollection $sharedContext,
+        Connector $connector,
+        EventFactoryInterface $eventFactory,
+        TransactionsStore $transactionsStore): ApmAgent
+    {
+        if (null === $this->startTime) {
+            $this->startTime = new RequestStartTime(microtime(true));
+        }
+
+        if (null === $this->collectors) {
+            $this->collectors = new Collection();
+        }
+
+        $agent = new Agent($config, $sharedContext, $connector, $eventFactory, $transactionsStore, $this->startTime);
+
+        $this->collectors->each(function (EventDataCollector $collector) use ($agent) {
+            $agent->addCollector($collector);
+        });
+
+        return $agent;
+    }
+}

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -11,15 +11,12 @@ use Illuminate\Support\Facades\Log;
 
 /**
  * Abstract class that provides base functionality to measure
- * events dispatched by the framnewrok or your application code.
+ * events dispatched by the framework or your application code.
  */
 abstract class EventDataCollector implements DataCollector
 {
     /** @var Application */
     protected $app;
-
-    /** @var Agent */
-    protected $agent;
 
     /** @var Collection */
     protected $started_measures;
@@ -33,17 +30,24 @@ abstract class EventDataCollector implements DataCollector
     /** @var float */
     protected $request_start_time;
 
-    public function __construct(Application $app, Agent $agent, Config $config)
+    /** @var Agent */
+    protected $agent;
+
+    final public function __construct(Application $app, Config $config, RequestStartTime $startTime)
     {
         $this->app = $app;
-        $this->agent = $agent;
         $this->config = $config;
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 
-        $this->request_start_time = $agent->getRequestStartTime();
+        $this->request_start_time = $startTime->microseconds();
 
         $this->registerEventListeners();
+    }
+
+    public function useAgent(Agent $agent): void
+    {
+        $this->agent = $agent;
     }
 
     /**

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -10,8 +10,8 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Facades\Log;
-use PhilKra\Events\Transaction;
-use PhilKra\Exception\Transaction\UnknownTransactionException;
+use Nipwaayoni\Events\Transaction;
+use Nipwaayoni\Exception\Transaction\UnknownTransactionException;
 use Throwable;
 
 /**

--- a/src/Collectors/RequestStartTime.php
+++ b/src/Collectors/RequestStartTime.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AG\ElasticApmLaravel\Collectors;
+
+class RequestStartTime
+{
+    /**
+     * @var float
+     */
+    private $startTime;
+
+    public function __construct(float $startTime)
+    {
+        $this->startTime = $startTime;
+    }
+
+    public function microseconds(): float
+    {
+        return $this->startTime;
+    }
+}

--- a/src/Contracts/DataCollector.php
+++ b/src/Contracts/DataCollector.php
@@ -2,10 +2,19 @@
 
 namespace AG\ElasticApmLaravel\Contracts;
 
+use AG\ElasticApmLaravel\Agent;
 use Illuminate\Support\Collection;
 
 interface DataCollector
 {
+    /*
+     * This allows making a concrete Agent available to the collector after everything
+     * is booted. The JobCollector class makes extensive use of the Agent, unlike other
+     * collectors. I think long term, creating a separate "middleware" for jobs will
+     * make make this unnecessary.
+     */
+    public function useAgent(Agent $agent): void;
+
     public function collect(): Collection;
 
     public function getName(): string;

--- a/src/Events/LazySpan.php
+++ b/src/Events/LazySpan.php
@@ -3,10 +3,10 @@
 namespace AG\ElasticApmLaravel\Events;
 
 use JsonSerializable;
-use PhilKra\Events\EventBean;
-use PhilKra\Events\TraceableEvent;
-use PhilKra\Helper\Encoding;
-use PhilKra\Traits\Events\Stacktrace;
+use Nipwaayoni\Events\EventBean;
+use Nipwaayoni\Events\TraceableEvent;
+use Nipwaayoni\Helper\Encoding;
+use Nipwaayoni\Traits\Events\Stacktrace;
 
 /**
  * Spans.
@@ -91,7 +91,7 @@ class LazySpan extends TraceableEvent implements JsonSerializable
     public function setStartTime(float $start_time): void
     {
         $this->start_time = $start_time;
-        $this->timestamp = $this->timestamp + $this->start_time * 1000;
+        $this->timestamp = $this->timestamp->asMicroSeconds() + $this->start_time * 1000;
     }
 
     /**

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -2,8 +2,8 @@
 
 namespace AG\ElasticApmLaravel\Middleware;
 
-use Closure;
 use AG\ElasticApmLaravel\Agent;
+use Closure;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -2,13 +2,13 @@
 
 namespace AG\ElasticApmLaravel\Middleware;
 
-use AG\ElasticApmLaravel\Agent;
 use Closure;
+use AG\ElasticApmLaravel\Agent;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Log;
-use PhilKra\Events\Transaction;
+use Nipwaayoni\Events\Transaction;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -69,7 +69,6 @@ class RecordTransaction
             'finished' => true,
             'headers_sent' => true,
             'status_code' => $response->getStatusCode(),
-            'headers' => $this->formatHeaders($response->headers->all()),
         ]);
 
         $user = $request->user();
@@ -151,12 +150,5 @@ class RecordTransaction
     {
         // Fix leading /
         return '/' . trim($uri, '/');
-    }
-
-    protected function formatHeaders(array $headers): array
-    {
-        return collect($headers)->map(function ($values) {
-            return head($values);
-        })->toArray();
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,12 @@
 
 namespace AG\ElasticApmLaravel;
 
+use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
+use AG\ElasticApmLaravel\Collectors\FrameworkCollector;
+use AG\ElasticApmLaravel\Collectors\HttpRequestCollector;
+use AG\ElasticApmLaravel\Collectors\JobCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
+use AG\ElasticApmLaravel\Collectors\SpanCollector;
 use AG\ElasticApmLaravel\Contracts\VersionResolver;
 use AG\ElasticApmLaravel\Middleware\RecordTransaction;
 use AG\ElasticApmLaravel\Services\ApmCollectorService;
@@ -9,11 +15,12 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
-use Nipwaayoni\AgentBuilder;
 use Nipwaayoni\Config;
 
 class ServiceProvider extends BaseServiceProvider
 {
+    public const COLLECTOR_TAG = 'event-collector';
+
     private $source_config_path = __DIR__ . '/../config/elastic-apm-laravel.php';
 
     /**
@@ -30,8 +37,14 @@ class ServiceProvider extends BaseServiceProvider
             return;
         }
 
+        // Create a single representation of the request start time which can be injected
+        // to other classes.
+        $this->app->singleton(RequestStartTime::class, function () {
+            return new RequestStartTime($this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true));
+        });
+
         $this->registerAgent();
-        $this->registerInitCollectors();
+        $this->registerCollectors();
     }
 
     /**
@@ -47,7 +60,6 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->registerMiddleware();
-        $this->registerCollectors();
     }
 
     /**
@@ -66,22 +78,18 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerAgent(): void
     {
         $this->app->singleton(Agent::class, function () {
-            $start_time = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
+            /** @var RequestStartTime $start_time */
+            $start_time = $this->app->make(RequestStartTime::class);
 
             /** @var AgentBuilder $builder */
             $builder = $this->app->make(AgentBuilder::class);
 
-            $builder->withAgentClass(Agent::class);
-            $builder->withConfig(new Config($this->getAgentConfig()));
-
-            $builder->withEnvData(config('elastic-apm-laravel.env.env'));
-
-            /** @var Agent $agent */
-            $agent = $builder->build();
-
-            $agent->setRequestStartTime($start_time);
-
-            return $agent;
+            return $builder
+                ->withConfig(new Config($this->getAgentConfig()))
+                ->withEnvData(config('elastic-apm-laravel.env.env'))
+                ->withRequestStartTime($start_time)
+                ->withEventCollectors(collect($this->app->tagged(self::COLLECTOR_TAG)))
+                ->build();
         });
 
         // Register a callback on terminating to send the events
@@ -104,21 +112,56 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Register data collectors and start listening for events.
+     * Register data collectors and start listening for events. Most collectors are
+     * registered by tagging the abstracts in the service container. The concreate
+     * implementations are not created during registration.
+     *
+     * An collectors which must be created prior to the boot phase should ensure
+     * they have no dependencies on other services which may not be registered yet.
+     *
+     * All tagged collectors will be gathered and given to the Agent when it is created.
      */
     protected function registerCollectors(): void
     {
-        $agent = $this->app->make(Agent::class);
-        $agent->registerCollectors();
+        if ($this->collectFrameworkEvents()) {
+            // Force the FrameworkCollector instance to be created and used. While this appears odd,
+            // the collector instance registers itself to listen for booting events, so that instance
+            // must be made available for collection later.
+            $this->app->instance(FrameworkCollector::class, $this->app->make(FrameworkCollector::class));
+
+            $this->app->tag(FrameworkCollector::class, self::COLLECTOR_TAG);
+        }
+
+        if (false !== config('elastic-apm-laravel.spans.querylog.enabled')) {
+            // DB Queries collector
+            $this->app->tag(DBQueryCollector::class, self::COLLECTOR_TAG);
+        }
+
+        // Http request collector
+        if ($this->collectHttpEvents()) {
+            $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
+        }
+
+        // Job collector
+        $this->app->tag(JobCollector::class, self::COLLECTOR_TAG);
+
+        // Collector for manual measurements throughout the app
+        $this->app->tag(SpanCollector::class, self::COLLECTOR_TAG);
     }
 
-    /**
-     * Register data collectors that require starting earlier - before boot.
-     */
-    protected function registerInitCollectors(): void
+    private function collectFrameworkEvents(): bool
     {
-        $agent = $this->app->make(Agent::class);
-        $agent->registerInitCollectors();
+        // For cli executions, like queue workers, the application
+        // only starts once. It doesn't really make sense to measure it.
+        // Right now, the only condition that determines the inclusion
+        // of framework events is being an http request. That may change
+        // in the future, so we will use a specific method.
+        return $this->collectHttpEvents();
+    }
+
+    private function collectHttpEvents(): bool
+    {
+        return 'cli' !== php_sapi_name();
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -60,6 +60,15 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->registerMiddleware();
+
+        // If not collecting http events, the http middleware will not be executed and an
+        // Agent will not exist prior to events occurring. Create one here to ensure the
+        // collectors all register their listeners before any work is done. Unlike the
+        // FrameWorkCollector, the JobCollector needs an Agent object so it cannot be
+        // created independently and discovered by the ServiceProvider later.
+        if (!$this->collectHttpEvents()) {
+            $this->app->make(Agent::class);
+        }
     }
 
     /**

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -8,7 +8,7 @@ use AG\ElasticApmLaravel\Events\StopMeasuring;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application;
-use PhilKra\Events\Transaction;
+use Nipwaayoni\Events\Transaction;
 use Throwable;
 
 class ApmCollectorService

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use Codeception\Test\Unit;
 use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use Illuminate\Config\Repository as Config;
@@ -35,10 +35,10 @@ class CustomCollectorTest extends Unit
     protected function _before()
     {
         $appMock = Mockery::mock(Application::class);
-        $agentMock = Mockery::mock(Agent::class);
+        $requestStartTimeMock = Mockery::mock(RequestStartTime::class);
         $configMock = Mockery::mock(Config::class);
 
-        $agentMock->shouldReceive('getRequestStartTime')
+        $requestStartTimeMock->shouldReceive('microseconds')
             ->once()
             ->andReturn(1000.0);
 
@@ -46,7 +46,7 @@ class CustomCollectorTest extends Unit
             ->once()
             ->with('registerEventListeners method has been called.');
 
-        $this->collector = new CustomCollector($appMock, $agentMock, $configMock);
+        $this->collector = new CustomCollector($appMock, $configMock, $requestStartTimeMock);
     }
 
     public function testEmptyMeasures()

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -13,8 +13,8 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Facades\Log;
-use PhilKra\Events\Transaction;
-use PhilKra\Exception\Transaction\UnknownTransactionException;
+use Nipwaayoni\Events\Transaction;
+use Nipwaayoni\Exception\Transaction\UnknownTransactionException;
 
 class JobCollectorTest extends Unit
 {

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -2,6 +2,7 @@
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\JobCollector;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use Codeception\Test\Unit;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Queue\Job;
@@ -23,11 +24,17 @@ class JobCollectorTest extends Unit
     private const JOB_IGNORE_PATTERN = "/\/health-check|This\\\\Is\\\\A\\\\Test\\\\Job/";
     private const REQUEST_START_TIME = 1000.0;
 
+    /** @var Application */
+    private $app;
+    /** @var Dispatcher */
+    private $dispatcher;
+
     /**
      * @var \AG\ElasticApmLaravel\Collectors\JobCollector
      */
     private $collector;
 
+    /** @var Agent|\Mockery\LegacyMockInterface|\Mockery\MockInterface */
     private $agentMock;
 
     protected function _before()
@@ -45,14 +52,16 @@ class JobCollectorTest extends Unit
         $this->transactionMock = Mockery::mock(Transaction::class);
 
         $this->agentMock = Mockery::mock(Agent::class);
-        $this->agentMock
-            ->shouldReceive('getRequestStartTime')
+
+        $requestStartTimeMock = Mockery::mock(RequestStartTime::class);
+        $requestStartTimeMock->shouldReceive('microseconds')
             ->once()
             ->andReturn(self::REQUEST_START_TIME);
 
         $this->configMock = Mockery::mock(Config::class);
 
-        $this->collector = new JobCollector($this->app, $this->agentMock, $this->configMock);
+        $this->collector = new JobCollector($this->app, $this->configMock, $requestStartTimeMock);
+        $this->collector->useAgent($this->agentMock);
     }
 
     protected function tearDown(): void

--- a/tests/unit/Events/LazySpanTest.php
+++ b/tests/unit/Events/LazySpanTest.php
@@ -2,14 +2,14 @@
 
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Codeception\Test\Unit;
-use PhilKra\Events\EventBean;
+use Nipwaayoni\Events\EventBean;
 
 class LazySpanTest extends Unit
 {
     /**
      * Parent transaction for LazySpan.
      *
-     * @var \PhilKra\Events\EventBean
+     * @var \Nipwaayoni\Events\EventBean
      */
     private $parent;
 

--- a/tests/unit/Middleware/RecordTransactionTest.php
+++ b/tests/unit/Middleware/RecordTransactionTest.php
@@ -126,7 +126,6 @@ class RecordTransactionTest extends Unit
             'finished' => true,
             'headers_sent' => true,
             'status_code' => 200,
-            'headers' => [],
         ], $context['response']);
 
         $this->assertEquals([

--- a/tests/unit/Middleware/RecordTransactionTest.php
+++ b/tests/unit/Middleware/RecordTransactionTest.php
@@ -8,7 +8,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
-use PhilKra\Events\Transaction;
+use Nipwaayoni\Events\Transaction;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class RecordTransactionTest extends Unit
@@ -34,7 +34,7 @@ class RecordTransactionTest extends Unit
     private $middleware;
 
     /**
-     * @var PhilKra\Events\Transaction
+     * @var Nipwaayoni\Events\Transaction
      */
     private $transaction;
 
@@ -127,7 +127,7 @@ class RecordTransactionTest extends Unit
             'headers_sent' => true,
             'status_code' => 200,
             'headers' => [],
-        ], $context['request']['response']);
+        ], $context['response']);
 
         $this->assertEquals([
             'id' => null,

--- a/tests/unit/Services/ApmCollectorServiceTest.php
+++ b/tests/unit/Services/ApmCollectorServiceTest.php
@@ -7,7 +7,7 @@ use Codeception\Test\Unit;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
-use PhilKra\Events\Transaction;
+use Nipwaayoni\Events\Transaction;
 
 class ApmCollectorServiceTest extends Unit
 {


### PR DESCRIPTION
The current Elastic PHP agent is not under maintenance anymore, and the author [agreed on transfering the ownership](https://github.com/philkra/elastic-apm-php-agent/issues/136#issuecomment-621883404) to an [organization](https://github.com/nipwaayoni/elastic-apm-php-agent). This PR contains the necessary changes to make this migration possible. Thanks to @dstepe who perfomed most of the work to make it happen.

It includes the following changes:
- Replace `philkra/elastic-apm-php-agent` with `nipwaayoni/elastic-apm-php-agent`.
- Refactor ServiceProvider:  the new Agent includes an AgentBuilder to facilitate constructing the agent. Use it to fulfill the Agent implementation in the service container.
- The Agent no longer relies on the class `__destruct()` method to call `send()`. We need to explicitly call `send()` on the agent which is best done in an `App::terminating()` registered callback. This is executed after the framework has sent the response to the consumer.
- Remove injection of Agent class into `EventDataCollector` classes.
- The `FrameworkCollector` is created during the Laravel 'register' phase, which was forcing the Agent to be constructed as well. This occurred before other service providers had completed registering and therefore prevented modifying the Agent construction through the AgentBuilder abstraction.
- Collectors are now tagged during 'register' and given to the Agent, rather than being created within the Agent.
- The Agent is given to the Collector objects during the add process to meet the need of the `JobCollector` interacting with it.

Because of the changes to the Agent, I think we should release a version 2 of the package. If any customer is extending the existing implementation, this new version will break their code.

Closes #52, closes #67 