### PR TITLE
fix: transaction and span times for async jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To record an additional span around your job execution, you may include the prov
 public function middleware()
 {
     return [
-        app(\AG\ElasticApmLaravel\Jobs\Middleware\RecordTransaction::class),
+        new \AG\ElasticApmLaravel\Jobs\Middleware\RecordTransaction,
     ];
 }
 ```

--- a/composer.lock
+++ b/composer.lock
@@ -2572,6 +2572,7 @@
                 "portable",
                 "shim"
             ],
+            "time": "2020-03-09T19:04:49+00:00"
         },
         {
             "name": "symfony/polyfill-php56",

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -2,7 +2,6 @@
 
 namespace AG\ElasticApmLaravel;
 
-use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Illuminate\Support\Collection;
@@ -28,19 +27,16 @@ use Nipwaayoni\Stores\TransactionsStore;
 class Agent extends NipwaayoniAgent
 {
     protected $collectors;
-    protected $request_start_time;
 
     public function __construct(
         Config $config,
-        ContextCollection $sharedContext,
+        ContextCollection $shared_context,
         Connector $connector,
-        EventFactoryInterface $eventFactory,
-        TransactionsStore $transactionsStore,
-        RequestStartTime $startTime
+        EventFactoryInterface $event_factory,
+        TransactionsStore $transactions_store
     ) {
-        parent::__construct($config, $sharedContext, $connector, $eventFactory, $transactionsStore);
+        parent::__construct($config, $shared_context, $connector, $event_factory, $transactions_store);
 
-        $this->request_start_time = $startTime->microseconds();
         $this->collectors = new Collection();
     }
 
@@ -76,10 +72,5 @@ class Agent extends NipwaayoniAgent
                 $this->putEvent($event);
             });
         });
-    }
-
-    public function getRequestStartTime(): float
-    {
-        return $this->request_start_time;
     }
 }

--- a/src/AgentBuilder.php
+++ b/src/AgentBuilder.php
@@ -3,7 +3,6 @@
 namespace AG\ElasticApmLaravel;
 
 use AG\ElasticApmLaravel\Collectors\EventDataCollector;
-use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use Illuminate\Support\Collection;
 use Nipwaayoni\AgentBuilder as NipwaayoniAgentBuilder;
 use Nipwaayoni\ApmAgent;
@@ -15,18 +14,8 @@ use Nipwaayoni\Stores\TransactionsStore;
 
 class AgentBuilder extends NipwaayoniAgentBuilder
 {
-    /** @var RequestStartTime */
-    private $start_time;
-
     /** @var Collection */
     private $collectors;
-
-    public function withRequestStartTime(RequestStartTime $start_time): self
-    {
-        $this->start_time = $start_time;
-
-        return $this;
-    }
 
     public function withEventCollectors(Collection $collectors): self
     {
@@ -42,15 +31,11 @@ class AgentBuilder extends NipwaayoniAgentBuilder
         EventFactoryInterface $event_factory,
         TransactionsStore $transactions_store): ApmAgent
     {
-        if (null === $this->start_time) {
-            $this->start_time = new RequestStartTime(microtime(true));
-        }
-
         if (null === $this->collectors) {
             $this->collectors = new Collection();
         }
 
-        $agent = new Agent($config, $shared_context, $connector, $event_factory, $transactions_store, $this->start_time);
+        $agent = new Agent($config, $shared_context, $connector, $event_factory, $transactions_store);
 
         $this->collectors->each(function (EventDataCollector $collector) use ($agent) {
             $agent->addCollector($collector);

--- a/src/AgentBuilder.php
+++ b/src/AgentBuilder.php
@@ -16,14 +16,14 @@ use Nipwaayoni\Stores\TransactionsStore;
 class AgentBuilder extends NipwaayoniAgentBuilder
 {
     /** @var RequestStartTime */
-    private $startTime;
+    private $start_time;
 
     /** @var Collection */
     private $collectors;
 
-    public function withRequestStartTime(RequestStartTime $startTime): self
+    public function withRequestStartTime(RequestStartTime $start_time): self
     {
-        $this->startTime = $startTime;
+        $this->start_time = $start_time;
 
         return $this;
     }
@@ -37,20 +37,20 @@ class AgentBuilder extends NipwaayoniAgentBuilder
 
     protected function newAgent(
         Config $config,
-        ContextCollection $sharedContext,
+        ContextCollection $shared_context,
         Connector $connector,
-        EventFactoryInterface $eventFactory,
-        TransactionsStore $transactionsStore): ApmAgent
+        EventFactoryInterface $event_factory,
+        TransactionsStore $transactions_store): ApmAgent
     {
-        if (null === $this->startTime) {
-            $this->startTime = new RequestStartTime(microtime(true));
+        if (null === $this->start_time) {
+            $this->start_time = new RequestStartTime(microtime(true));
         }
 
         if (null === $this->collectors) {
             $this->collectors = new Collection();
         }
 
-        $agent = new Agent($config, $sharedContext, $connector, $eventFactory, $transactionsStore, $this->startTime);
+        $agent = new Agent($config, $shared_context, $connector, $event_factory, $transactions_store, $this->start_time);
 
         $this->collectors->each(function (EventDataCollector $collector) use ($agent) {
             $agent->addCollector($collector);

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -32,7 +32,7 @@ class DBQueryCollector extends EventDataCollector implements DataCollector
             }
         }
 
-        $start_time = microtime(true) - $this->request_start_time - $query->time / 1000;
+        $start_time = microtime(true) - $this->start_time->microseconds() - $query->time / 1000;
         $end_time = $start_time + $query->time / 1000;
 
         $query = [

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -3,7 +3,6 @@
 namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Agent;
-use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -3,6 +3,7 @@
 namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Agent;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use AG\ElasticApmLaravel\Contracts\DataCollector;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
@@ -27,20 +28,20 @@ abstract class EventDataCollector implements DataCollector
     /** @var Config */
     protected $config;
 
-    /** @var float */
-    protected $request_start_time;
+    /** @var RequestStartTime */
+    protected $start_time;
 
     /** @var Agent */
     protected $agent;
 
-    final public function __construct(Application $app, Config $config, RequestStartTime $startTime)
+    final public function __construct(Application $app, Config $config, RequestStartTime $start_time)
     {
         $this->app = $app;
         $this->config = $config;
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 
-        $this->request_start_time = $startTime->microseconds();
+        $this->start_time = $start_time;
 
         $this->registerEventListeners();
     }
@@ -69,7 +70,7 @@ abstract class EventDataCollector implements DataCollector
 
         $this->started_measures->put($name, [
             'label' => $label ?: $name,
-            'start' => $start - $this->request_start_time,
+            'start' => $start - $this->start_time->microseconds(),
             'type' => $type,
             'action' => $action,
         ]);
@@ -99,7 +100,7 @@ abstract class EventDataCollector implements DataCollector
         $this->addMeasure(
             $measure['label'],
             $measure['start'],
-            $end - $this->request_start_time,
+            $end - $this->start_time->microseconds(),
             $measure['type'],
             $measure['action'],
             $params

--- a/src/Collectors/RequestStartTime.php
+++ b/src/Collectors/RequestStartTime.php
@@ -7,15 +7,24 @@ class RequestStartTime
     /**
      * @var float
      */
-    private $startTime;
+    private $start_time;
 
-    public function __construct(float $startTime)
+    public function __construct(float $start_time)
     {
-        $this->startTime = $startTime;
+        $this->start_time = $start_time;
+    }
+
+    /**
+     * Allow override the start time value for queued jobs,
+     * where the application starts only once.
+     */
+    public function setStartTime(float $start_time): void
+    {
+        $this->start_time = $start_time;
     }
 
     public function microseconds(): float
     {
-        return $this->startTime;
+        return $this->start_time;
     }
 }

--- a/src/Jobs/Middleware/RecordTransaction.php
+++ b/src/Jobs/Middleware/RecordTransaction.php
@@ -20,7 +20,7 @@ class RecordTransaction
             return $next($job);
         }
 
-        ApmCollector::startMeasure('job_processing', 'job', 'processing', get_class($job) . ' processing');
+        ApmCollector::startMeasure('job_processing', 'job', 'handle', get_class($job) . '::handle');
 
         $next($job);
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -3,6 +3,7 @@
 namespace AG\ElasticApmLaravel\Middleware;
 
 use AG\ElasticApmLaravel\Agent;
+use AG\ElasticApmLaravel\Collectors\RequestStartTime;
 use Closure;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
@@ -27,11 +28,13 @@ class RecordTransaction
 {
     protected $agent;
     protected $config;
+    protected $start_time;
 
-    public function __construct(Agent $agent, Config $config)
+    public function __construct(Agent $agent, Config $config, RequestStartTime $start_time)
     {
         $this->agent = $agent;
         $this->config = $config;
+        $this->start_time = $start_time;
     }
 
     /**
@@ -117,7 +120,7 @@ class RecordTransaction
         return $this->agent->startTransaction(
             $transaction_name,
             [],
-            $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true)
+            $this->start_time->microseconds()
         );
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -87,16 +87,12 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerAgent(): void
     {
         $this->app->singleton(Agent::class, function () {
-            /** @var RequestStartTime $start_time */
-            $start_time = $this->app->make(RequestStartTime::class);
-
             /** @var AgentBuilder $builder */
             $builder = $this->app->make(AgentBuilder::class);
 
             return $builder
                 ->withConfig(new Config($this->getAgentConfig()))
                 ->withEnvData(config('elastic-apm-laravel.env.env'))
-                ->withRequestStartTime($start_time)
                 ->withEventCollectors(collect($this->app->tagged(self::COLLECTOR_TAG)))
                 ->build();
         });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -125,7 +125,7 @@ class ServiceProvider extends BaseServiceProvider
      * registered by tagging the abstracts in the service container. The concreate
      * implementations are not created during registration.
      *
-     * An collectors which must be created prior to the boot phase should ensure
+     * All collectors which must be created prior to the boot phase should ensure
      * they have no dependencies on other services which may not be registered yet.
      *
      * All tagged collectors will be gathered and given to the Agent when it is created.
@@ -165,12 +165,12 @@ class ServiceProvider extends BaseServiceProvider
         // Right now, the only condition that determines the inclusion
         // of framework events is being an http request. That may change
         // in the future, so we will use a specific method.
-        return $this->collectHttpEvents();
+        return !$this->app->runningInConsole();
     }
 
     private function collectHttpEvents(): bool
     {
-        return 'cli' !== php_sapi_name();
+        return !$this->app->runningInConsole();
     }
 
     /**
@@ -218,6 +218,6 @@ class ServiceProvider extends BaseServiceProvider
     private function isAgentDisabled(): bool
     {
         return false === config('elastic-apm-laravel.active')
-            || ('cli' === php_sapi_name() && false === config('elastic-apm-laravel.cli.active'));
+            || ($this->app->runningInConsole() && false === config('elastic-apm-laravel.cli.active'));
     }
 }

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -34,7 +34,7 @@ class ApmCollectorService
         $this->events = $events;
 
         $this->is_agent_disabled = false === $config->get('elastic-apm-laravel.active')
-            || ('cli' === php_sapi_name() && false === $config->get('elastic-apm-laravel.cli.active'));
+            || ($this->app->runningInConsole() && false === $config->get('elastic-apm-laravel.cli.active'));
     }
 
     public function startMeasure(

--- a/tests/unit/Collectors/CustomCollectorTest.php
+++ b/tests/unit/Collectors/CustomCollectorTest.php
@@ -39,7 +39,6 @@ class CustomCollectorTest extends Unit
         $configMock = Mockery::mock(Config::class);
 
         $requestStartTimeMock->shouldReceive('microseconds')
-            ->once()
             ->andReturn(1000.0);
 
         Log::shouldReceive('info')

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -45,7 +45,7 @@ class JobCollectorTest extends Unit
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $requestStartTimeMock = Mockery::mock(RequestStartTime::class);
         $requestStartTimeMock->shouldReceive('setStartTime');
         $requestStartTimeMock->shouldReceive('microseconds')->andReturn(1000.0);

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -46,17 +46,16 @@ class JobCollectorTest extends Unit
     protected function setUp(): void
     {
         parent::setUp();
+        
+        $requestStartTimeMock = Mockery::mock(RequestStartTime::class);
+        $requestStartTimeMock->shouldReceive('setStartTime');
+        $requestStartTimeMock->shouldReceive('microseconds')->andReturn(1000.0);
 
         $this->jobMock = Mockery::mock(Job::class);
 
         $this->transactionMock = Mockery::mock(Transaction::class);
 
         $this->agentMock = Mockery::mock(Agent::class);
-
-        $requestStartTimeMock = Mockery::mock(RequestStartTime::class);
-        $requestStartTimeMock->shouldReceive('microseconds')
-            ->once()
-            ->andReturn(self::REQUEST_START_TIME);
 
         $this->configMock = Mockery::mock(Config::class);
 

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -22,7 +22,6 @@ class JobCollectorTest extends Unit
     private const JOB_NAME = 'This\Is\A\Test\Job';
     // Use 4 backslashes to match a single backslash: https://stackoverflow.com/a/15369828
     private const JOB_IGNORE_PATTERN = "/\/health-check|This\\\\Is\\\\A\\\\Test\\\\Job/";
-    private const REQUEST_START_TIME = 1000.0;
 
     /** @var Application */
     private $app;

--- a/tests/unit/Services/ApmCollectorServiceTest.php
+++ b/tests/unit/Services/ApmCollectorServiceTest.php
@@ -27,6 +27,8 @@ class ApmCollectorServiceTest extends Unit
         $this->configMock = Mockery::mock(Config::class);
         $this->eventsMock = Mockery::mock(Dispatcher::class);
 
+        $this->appMock->shouldReceive('runningInConsole')
+            ->andReturn(true);
         $this->configMock->shouldReceive('get')
             ->once()
             ->with('elastic-apm-laravel.active')


### PR DESCRIPTION
This fixed an issue with timing on asynchronous jobs. We depend on `RequestStartTime` to calculate when spans start in relation to the transaction, but for async jobs, this class holds the time when the queue was started, not when the transaction was started, showing an incorrect timeline for jobs.

I created a new method that allows overriding the `$start_time` value, which is called when a job starts processing, but only for async queues. That way, every time a job is processed, we can set the correct starting time.

Bonus points:
- Use Laravel's `runningInConsole` method to detect if we are running the code in the console, instead of depending on `php_sapi_name` output.
- Use snake_case notation for variable names. We follow this pattern, even though is not mentioned anywhere.

@dstepe could you take a look?