### PR TITLE
Reset EventDataCollectors and add Metadata after each send

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -120,7 +120,7 @@ class Agent extends PhilKraAgent
          * worker processes. A future release of the Agent package should handle event
          * collection better and remove the need for this.
          */
-        $this->putEvent(new Metadata([], $this->getConfig(), $this->agentMetadata()));
+        $this->putEvent(new Metadata([], $this->getConfig()));
 
         return $sent;
     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -3,6 +3,7 @@
 namespace AG\ElasticApmLaravel;
 
 use AG\ElasticApmLaravel\Collectors\DBQueryCollector;
+use AG\ElasticApmLaravel\Collectors\EventDataCollector;
 use AG\ElasticApmLaravel\Collectors\FrameworkCollector;
 use AG\ElasticApmLaravel\Collectors\HttpRequestCollector;
 use AG\ElasticApmLaravel\Collectors\JobCollector;
@@ -11,6 +12,7 @@ use AG\ElasticApmLaravel\Contracts\DataCollector;
 use AG\ElasticApmLaravel\Events\LazySpan;
 use Illuminate\Support\Collection;
 use PhilKra\Agent as PhilKraAgent;
+use PhilKra\Events\Metadata;
 
 /**
  * The Elastic APM agent sends performance metrics and error logs to the APM Server.
@@ -101,5 +103,25 @@ class Agent extends PhilKraAgent
     public function getRequestStartTime(): float
     {
         return $this->request_start_time;
+    }
+
+    public function send(): bool
+    {
+        $sent = parent::send();
+
+        // Ensure collectors are reset after data is sent to APM
+        $this->collectors->each(function (EventDataCollector $collector) {
+            $collector->reset();
+        });
+
+        /*
+         * Push new metadata onto the stack in preparation for the next send event. This
+         * simulates the behavior when a new Agent is created and is needed for long running
+         * worker processes. A future release of the Agent package should handle event
+         * collection better and remove the need for this.
+         */
+        $this->putEvent(new Metadata([], $this->getConfig(), $this->agentMetadata()));
+
+        return $sent;
     }
 }

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -136,4 +136,10 @@ abstract class EventDataCollector implements DataCollector
     {
         return round($time * 1000, 3);
     }
+
+    public function reset(): void
+    {
+        $this->started_measures = new Collection();
+        $this->measures = new Collection();
+    }
 }

--- a/src/Contracts/DataCollector.php
+++ b/src/Contracts/DataCollector.php
@@ -11,4 +11,6 @@ interface DataCollector
     public function getName(): string;
 
     public function registerEventListeners(): void;
+
+    public function reset(): void;
 }


### PR DESCRIPTION
Closes #57 

The current event collection results in problems with long running worker processes. The required metadata is not being added before each batch and the event collectors are not being cleared after sending. Overriding the base `Agent::send()` allows us to work around both issues as a short term fix. The base `Agent` package will improve the event collection process in a future release to address this. You may want to look into a better way to reset the collectors in this package.

I have tested this on my reference application with a worker queue and it appears to work as expected. However, I do not have the philkra agent package installed and cannot attest to this being fully ready to merge. I offer is a starting point for addressing the reported issue.