### PR TITLE
chore: fix variable casing

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -34,15 +34,15 @@ class Agent extends NipwaayoniAgent
 
     public function __construct(
         Config $config,
-        ContextCollection $sharedContext,
+        ContextCollection $shared_context,
         Connector $connector,
-        EventFactoryInterface $eventFactory,
-        TransactionsStore $transactionsStore,
-        RequestStartTime $startTime
+        EventFactoryInterface $event_factory,
+        TransactionsStore $transactions_store,
+        RequestStartTime $start_time
     ) {
-        parent::__construct($config, $sharedContext, $connector, $eventFactory, $transactionsStore);
+        parent::__construct($config, $shared_context, $connector, $event_factory, $transactions_store);
 
-        $this->request_start_time = $startTime->microseconds();
+        $this->request_start_time = $start_time->microseconds();
         $this->collectors = new Collection();
     }
 

--- a/src/AgentBuilder.php
+++ b/src/AgentBuilder.php
@@ -16,14 +16,14 @@ use Nipwaayoni\Stores\TransactionsStore;
 class AgentBuilder extends NipwaayoniAgentBuilder
 {
     /** @var RequestStartTime */
-    private $startTime;
+    private $start_time;
 
     /** @var Collection */
     private $collectors;
 
-    public function withRequestStartTime(RequestStartTime $startTime): self
+    public function withRequestStartTime(RequestStartTime $start_time): self
     {
-        $this->startTime = $startTime;
+        $this->start_time = $start_time;
 
         return $this;
     }
@@ -37,20 +37,20 @@ class AgentBuilder extends NipwaayoniAgentBuilder
 
     protected function newAgent(
         Config $config,
-        ContextCollection $sharedContext,
+        ContextCollection $shared_context,
         Connector $connector,
-        EventFactoryInterface $eventFactory,
-        TransactionsStore $transactionsStore): ApmAgent
+        EventFactoryInterface $event_factory,
+        TransactionsStore $transactions_store): ApmAgent
     {
-        if (null === $this->startTime) {
-            $this->startTime = new RequestStartTime(microtime(true));
+        if (null === $this->start_time) {
+            $this->start_time = new RequestStartTime(microtime(true));
         }
 
         if (null === $this->collectors) {
             $this->collectors = new Collection();
         }
 
-        $agent = new Agent($config, $sharedContext, $connector, $eventFactory, $transactionsStore, $this->startTime);
+        $agent = new Agent($config, $shared_context, $connector, $event_factory, $transactions_store, $this->start_time);
 
         $this->collectors->each(function (EventDataCollector $collector) use ($agent) {
             $agent->addCollector($collector);

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -33,14 +33,14 @@ abstract class EventDataCollector implements DataCollector
     /** @var Agent */
     protected $agent;
 
-    final public function __construct(Application $app, Config $config, RequestStartTime $startTime)
+    final public function __construct(Application $app, Config $config, RequestStartTime $start_time)
     {
         $this->app = $app;
         $this->config = $config;
         $this->started_measures = new Collection();
         $this->measures = new Collection();
 
-        $this->request_start_time = $startTime->microseconds();
+        $this->request_start_time = $start_time->microseconds();
 
         $this->registerEventListeners();
     }

--- a/src/Collectors/RequestStartTime.php
+++ b/src/Collectors/RequestStartTime.php
@@ -7,15 +7,15 @@ class RequestStartTime
     /**
      * @var float
      */
-    private $startTime;
+    private $start_time;
 
-    public function __construct(float $startTime)
+    public function __construct(float $start_time)
     {
-        $this->startTime = $startTime;
+        $this->start_time = $start_time;
     }
 
     public function microseconds(): float
     {
-        return $this->startTime;
+        return $this->start_time;
     }
 }


### PR DESCRIPTION
We use `snake_case` to define our variables, properties and function arguments. Fix the variables that don't follow this pattern.