### PR TITLE
fix(config): default service name value

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -197,7 +197,7 @@ class ServiceProvider extends BaseServiceProvider
         // Filter out null config options so that the Config class can look for environment variables
         return array_filter(array_merge(
             [
-                'defaultServiceName' => 'Laravel',
+                'defaultServiceName' => config('elastic-apm-laravel.app.appName', 'Laravel'),
                 'frameworkName' => 'Laravel',
                 'frameworkVersion' => app()->version(),
                 'active' => config('elastic-apm-laravel.active'),


### PR DESCRIPTION
The existing `APM_APPNAME` environment variable is getting ignored and replaced by the default config value `defaultServiceName`. To prevent breaking changes on existing applications, I'm setting the default value to the existing value if it exists.

@dstepe could you take a look? The rest of the values look that they are correctly set.