### PR TITLE
Fix CommandStartingListener test

### DIFF
--- a/tests/unit/Collectors/CommandCollectorTest.php
+++ b/tests/unit/Collectors/CommandCollectorTest.php
@@ -113,14 +113,14 @@ class CommandCollectorTest extends Unit
 
     public function testCommandStartingListener(): void
     {
-        self::markTestSkipped('something weird is happening here');
-
         $this->patternConfigReturn();
 
         $this->agentMock->expects('getTransaction')
             ->with(self::COMMAND_NAME)
+            ->andReturn(null);
+        $this->agentMock->expects('startTransaction')
+            ->with(self::COMMAND_NAME, [], \Mockery::any())
             ->andReturn($this->transactionMock);
-        $this->agentMock->expects('startTransaction')->with(self::COMMAND_NAME, ['result' => 200]);
 
         $this->dispatcher->dispatch(
             new CommandStarting(


### PR DESCRIPTION
I believe this fixes the skipped test:

https://github.com/arkaitzgarro/elastic-apm-laravel/blob/master/tests/unit/Collectors/CommandCollectorTest.php#L116