### PR TITLE
chore: setup code climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
     docker:
       - image: circleci/php:7.3
     working_directory: ~/elastic-apm-laravel
+    environment:
+      CC_TEST_REPORTER_ID: 23639f09f4ef515ddb5fea9baf90f9f5cd9bb5e0801cf1dc062d993a3d70d3eb
     steps:
       - checkout
       - restore_cache:
@@ -49,8 +51,17 @@ jobs:
           name: Composer install
           command: composer install -n --prefer-dist
       - run:
+          name: Install Code Climate
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
           name: Run unit tests
-          command: ./vendor/bin/codecept run --xml test_report.xml --coverage --coverage-html --coverage-xml
+          command: |
+            ./cc-test-reporter before-build
+            ./vendor/bin/codecept run --xml test_report.xml --coverage --coverage-html --coverage-xml
+            mv tests/_output/coverage.xml clover.xml 
+            ./cc-test-reporter after-build --coverage-input-type clover --exit-code $?
       - store_test_results:
           path: tests/_output
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/arkaitzgarro/elastic-apm-laravel.svg?style=svg)](https://circleci.com/gh/arkaitzgarro/elastic-apm-laravel)
 [![Latest Stable Version](https://poser.pugx.org/arkaitzgarro/elastic-apm-laravel/v/stable)](https://packagist.org/packages/arkaitzgarro/elastic-apm-laravel)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/e5a66b9bf5161e299c8c/test_coverage)](https://codeclimate.com/github/arkaitzgarro/elastic-apm-laravel/test_coverage)
 [![License](https://poser.pugx.org/arkaitzgarro/elastic-apm-laravel/license)](https://packagist.org/packages/arkaitzgarro/elastic-apm-laravel)
 
 Elastic APM agent for v2 intake API. Compatible with Laravel 5.5+.


### PR DESCRIPTION
Setup Code Climate to keep track of out code coverage progress, enforce a minimum coverage on PRs and also analyse the complexity of the code.