### PR TITLE
Chore/update supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
+          environment:
+            COMPOSER_MEMORY_LIMIT: -1
       - save_cache:
           key: composer-v1-{{ checksum "composer.json" }}
           paths:
@@ -35,6 +37,8 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
+          environment:
+            COMPOSER_MEMORY_LIMIT: -1
       - run:
           name: Lint PHP code
           command: php ./vendor/bin/php-cs-fixer fix --config .php_cs --dry-run --diff
@@ -55,6 +59,8 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
+          environment:
+            COMPOSER_MEMORY_LIMIT: -1
       - run:
           name: Install Code Climate
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -15,8 +15,6 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
-          environment:
-            COMPOSER_MEMORY_LIMIT: -1
       - save_cache:
           key: composer-v1-{{ checksum "composer.json" }}
           paths:
@@ -37,15 +35,23 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
-          environment:
-            COMPOSER_MEMORY_LIMIT: -1
       - run:
           name: Lint PHP code
           command: php ./vendor/bin/php-cs-fixer fix --config .php_cs --dry-run --diff
 
   unit_tests:
+    parameters:
+      php-version:
+        type: string
+        default: "7.3"
+      laravel-version:
+        type: string
+        default: "6.*"
+      testbench-version:
+        type: string
+        default: "4.*"
     docker:
-      - image: circleci/php:7.3
+      - image: circleci/php:<< parameters.php-version >>
     working_directory: ~/elastic-apm-laravel
     environment:
       CC_TEST_REPORTER_ID: 23639f09f4ef515ddb5fea9baf90f9f5cd9bb5e0801cf1dc062d993a3d70d3eb
@@ -54,13 +60,11 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - composer-v1-{{ checksum "composer.json" }}
+            - composer-v1-{{ checksum "composer.json" }}-<< parameters.laravel-version >>
             - composer-v1-
-      - run:
-          name: Composer install
-          command: composer install -n --prefer-dist
-          environment:
-            COMPOSER_MEMORY_LIMIT: -1
+      - run: |
+          composer require "laravel/framework:<< parameters.laravel-version >>" "orchestra/testbench:<< parameters.testbench-version >>" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-suggest
       - run:
           name: Install Code Climate
           command: |
@@ -73,6 +77,11 @@ jobs:
             ./vendor/bin/codecept run --xml test_report.xml --coverage --coverage-html --coverage-xml
             mv tests/_output/coverage.xml clover.xml
             ./cc-test-reporter after-build --coverage-input-type clover --exit-code $?
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}-<< parameters.laravel-version >>
+          paths:
+            - vendor
+            - composer.lock
       - store_test_results:
           path: tests/_output
       - store_artifacts:
@@ -89,3 +98,45 @@ workflows:
       - unit_tests:
           requires:
             - build
+          matrix:
+            parameters:
+              php-version: ["7.3", "7.4"]
+              laravel-version: ["6.*", "7.*", "8.*"]
+              testbench-version: ["4.*", "5.*", "6.*"]
+            exclude:
+              - php-version: "7.3"
+                laravel-version: "6.*"
+                testbench-version: "5.*"
+              - php-version: "7.3"
+                laravel-version: "6.*"
+                testbench-version: "6.*"
+              - php-version: "7.4"
+                laravel-version: "6.*"
+                testbench-version: "5.*"
+              - php-version: "7.4"
+                laravel-version: "6.*"
+                testbench-version: "6.*"
+              - php-version: "7.3"
+                laravel-version: "7.*"
+                testbench-version: "4.*"
+              - php-version: "7.3"
+                laravel-version: "7.*"
+                testbench-version: "6.*"
+              - php-version: "7.4"
+                laravel-version: "7.*"
+                testbench-version: "4.*"
+              - php-version: "7.4"
+                laravel-version: "7.*"
+                testbench-version: "6.*"
+              - php-version: "7.3"
+                laravel-version: "8.*"
+                testbench-version: "4.*"
+              - php-version: "7.3"
+                laravel-version: "8.*"
+                testbench-version: "5.*"
+              - php-version: "7.4"
+                laravel-version: "8.*"
+                testbench-version: "4.*"
+              - php-version: "7.4"
+                laravel-version: "8.*"
+                testbench-version: "5.*"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     "require": {
         "php": ">=7.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^5.5|^6|^7",
-        "illuminate/http": "^5.5|^6|^7",
-        "illuminate/routing": "^5.5|^6|^7",
-        "illuminate/support": "^5.5|^6|^7",
+        "illuminate/database": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/http": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/routing": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "jasny/dbquery-mysql": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },
@@ -28,7 +28,7 @@
         "codeception/mockery-module": "^0.4.0",
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^3.5",
+        "orchestra/testbench": "^4.0",
         "php-http/guzzle7-adapter": "^0.1.0",
         "symfony/service-contracts": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "codeception/mockery-module": "^0.4.0",
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
         "php-http/guzzle7-adapter": "^0.1.0",
         "symfony/service-contracts": "^2.0"
     },


### PR DESCRIPTION
This drops support for Laravel 5.5 and adds support for Laravel 8.x.