### PR TITLE
chore: add unit tests for ScheduledTaskCollector class

### DIFF
--- a/src/Collectors/CommandCollector.php
+++ b/src/Collectors/CommandCollector.php
@@ -25,19 +25,13 @@ class CommandCollector extends EventDataCollector implements DataCollector
     {
         $this->app->events->listen(CommandStarting::class, function (CommandStarting $event) {
             $transaction_name = $this->getTransactionName($event);
-            if (!$transaction_name) {
-                return;
+            if ($transaction_name) {
+                $transaction = $this->getTransaction($transaction_name);
+                if (!$transaction) {
+                    $transaction = $this->startTransaction($transaction_name);
+                    $this->addMetadata($transaction);
+                }
             }
-
-            $transaction = $this->getTransaction($transaction_name);
-            if ($transaction) {
-                // Somehow, a transaction with the same name has already been created.
-                // If so, ignore this job, otherwise the agent will throw an exception.
-                return;
-            }
-
-            $transaction = $this->startTransaction($transaction_name);
-            $this->addMetadata($transaction);
         });
 
         $this->app->events->listen(CommandFinished::class, function (CommandFinished $event) {

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -33,20 +33,14 @@ class JobCollector extends EventDataCollector implements DataCollector
             }
 
             $transaction_name = $this->getTransactionName($event);
-            if (!$transaction_name) {
-                return;
+            if ($transaction_name) {
+                $transaction = $this->getTransaction($transaction_name);
+                if (!$transaction) {
+                    $this->startTransaction($transaction_name);
+                    $this->setTransactionType($transaction_name);
+                    $this->addMetadata($transaction_name, $event->job);
+                }
             }
-
-            $transaction = $this->getTransaction($transaction_name);
-            if ($transaction) {
-                // Somehow, a transaction with the same name has already been created.
-                // If so, ignore this job, otherwise the agent will throw an exception.
-                return;
-            }
-
-            $this->startTransaction($transaction_name);
-            $this->setTransactionType($transaction_name);
-            $this->addMetadata($transaction_name, $event->job);
         });
 
         $this->app->events->listen(JobProcessed::class, function (JobProcessed $event) {

--- a/src/Collectors/ScheduledTaskCollector.php
+++ b/src/Collectors/ScheduledTaskCollector.php
@@ -26,19 +26,13 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
     {
         $this->app->events->listen(ScheduledTaskStarting::class, function (ScheduledTaskStarting $event) {
             $transaction_name = $this->getTransactionName($event);
-            if (!$transaction_name) {
-                return;
+            if ($transaction_name) {
+                $transaction = $this->getTransaction($transaction_name);
+                if (!$transaction) {
+                    $transaction = $this->startTransaction($transaction_name);
+                    $this->addMetadata($transaction);
+                }
             }
-
-            $transaction = $this->getTransaction($transaction_name);
-            if ($transaction) {
-                // Somehow, a transaction with the same name has already been created.
-                // If so, ignore this job, otherwise the agent will throw an exception.
-                return;
-            }
-
-            $transaction = $this->startTransaction($transaction_name);
-            $this->addMetadata($transaction);
         });
 
         $this->app->events->listen(ScheduledTaskSkipped::class, function (ScheduledTaskSkipped $event) {
@@ -46,7 +40,7 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
             if ($transaction_name) {
                 $transaction = $this->getTransaction($transaction_name);
                 if ($transaction) {
-                    $this->stopTransaction($transaction_name, 200);
+                    $this->stopTransaction($transaction_name, $event->task->exitCode);
                 }
             }
         });
@@ -56,7 +50,7 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
             if ($transaction_name) {
                 $transaction = $this->getTransaction($transaction_name);
                 if ($transaction) {
-                    $this->stopTransaction($transaction_name, 200);
+                    $this->stopTransaction($transaction_name, $event->task->exitCode);
                     $this->send($event);
                 }
             }
@@ -65,12 +59,10 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
 
     protected function startTransaction(string $transaction_name): Transaction
     {
-        $start_time = microtime(true);
-
         return $this->agent->startTransaction(
             $transaction_name,
             [],
-            $start_time
+            $this->event_clock->microtime()
         );
     }
 

--- a/tests/unit/Collectors/CommandCollectorTest.php
+++ b/tests/unit/Collectors/CommandCollectorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandCollectorTest extends Unit
 {
     private const COMMAND_NAME = 'work:do';
+    
     // Use 4 backslashes to match a single backslash: https://stackoverflow.com/a/15369828
     private const COMMAND_IGNORE_PATTERN = '/(?:Application\\\\Commands\\\\DoWork|work:do)/';
 
@@ -36,7 +37,7 @@ class CommandCollectorTest extends Unit
     /** @var Agent|LegacyMockInterface|MockInterface */
     private $agentMock;
 
-    /** @var LegacyMockInterface|MockInterface|Transaction */
+    /** @var Transaction|LegacyMockInterface|MockInterface */
     private $transactionMock;
 
     /** @var Config|LegacyMockInterface|MockInterface */

--- a/tests/unit/Collectors/CommandCollectorTest.php
+++ b/tests/unit/Collectors/CommandCollectorTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandCollectorTest extends Unit
 {
     private const COMMAND_NAME = 'work:do';
-    
+
     // Use 4 backslashes to match a single backslash: https://stackoverflow.com/a/15369828
     private const COMMAND_IGNORE_PATTERN = '/(?:Application\\\\Commands\\\\DoWork|work:do)/';
 

--- a/tests/unit/Collectors/ScheduledTaskCollectorTest.php
+++ b/tests/unit/Collectors/ScheduledTaskCollectorTest.php
@@ -7,11 +7,24 @@ use AG\ElasticApmLaravel\Collectors\ScheduledTaskCollector;
 use AG\ElasticApmLaravel\EventClock;
 use Codeception\Test\Unit;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskSkipped;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Console\Scheduling\Event;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Log;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
+use Nipwaayoni\Events\Transaction;
 
 class ScheduledTaskCollectorTest extends Unit
 {
+    private const COMMAND_NAME = 'command:name';
+
+    // Use 4 backslashes to match a single backslash: https://stackoverflow.com/a/15369828
+    private const TASK_IGNORE_PATTERN = '/(?:Application\\\\Commands\\\\DoWork|work:do)/';
+
     /** @var Application */
     private $app;
 
@@ -21,27 +34,163 @@ class ScheduledTaskCollectorTest extends Unit
     /** @var ScheduledTaskCollector */
     private $collector;
 
+    /** @var Agent|LegacyMockInterface|MockInterface */
+    private $agentMock;
+
+    /** @var Transaction|LegacyMockInterface|MockInterface */
+    private $transactionMock;
+
+    /** @var Config|LegacyMockInterface|MockInterface */
+    private $configMock;
+
+    /** @var EventClock|LegacyMockInterface|MockInterface */
+    private $eventClockMock;
+
+    /** @var Event|LegacyMockInterface|MockInterface */
+    private $eventMock;
+
     protected function _before(): void
     {
         $this->app = app(Application::class);
         $this->dispatcher = app(Dispatcher::class);
 
+        $this->transactionMock = Mockery::mock(Transaction::class);
+        $this->agentMock = Mockery::mock(Agent::class);
+        $this->configMock = Mockery::mock(Config::class);
+        $this->eventMock = Mockery::mock(Event::class);
+        $this->eventClockMock = Mockery::mock(EventClock::class);
+
+        $this->eventMock->command = self::COMMAND_NAME;
+        $this->eventMock->exitCode = 0;
+
         $eventCounter = new EventCounter();
-        $eventClock = new EventClock();
 
         $this->collector = new ScheduledTaskCollector(
             $this->app,
-            new Config([]),
+            $this->configMock,
             new RequestStartTime(0.0),
             $eventCounter,
-            $eventClock
+            $this->eventClockMock
         );
 
-        $this->collector->useAgent(Mockery::mock(Agent::class));
+        $this->collector->useAgent($this->agentMock);
+    }
+
+    protected function _after(): void
+    {
+        $this->dispatcher->forget(ScheduledTaskStarting::class);
+        $this->dispatcher->forget(ScheduledTaskSkipped::class);
+        $this->dispatcher->forget(ScheduledTaskFinished::class);
+    }
+
+    protected function patternConfigReturn($configIgnore = null): void
+    {
+        $this->configMock->expects('get')
+            ->with('elastic-apm-laravel.transactions.ignorePatterns')
+            ->andReturn($configIgnore);
     }
 
     public function testCollectorName(): void
     {
         self::assertEquals('scheduled-task-collector', $this->collector->getName());
+    }
+
+    public function testScheduledTaskStartingListenerIgnored(): void
+    {
+        $this->eventMock->command = 'work:do';
+        $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
+        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+
+        $this->dispatcher->dispatch(new ScheduledTaskStarting($this->eventMock));
+    }
+
+    public function testScheduledTaskSkippedListenerIgnored(): void
+    {
+        $this->eventMock->command = 'work:do';
+        $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
+        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+
+        $this->dispatcher->dispatch(new ScheduledTaskSkipped($this->eventMock));
+    }
+
+    public function testScheduledTaskFinishedListenerIgnored(): void
+    {
+        $this->eventMock->command = 'work:do';
+        $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
+        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+
+        $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0));
+    }
+
+    public function testScheduledTaskStartingListener(): void
+    {
+        $this->patternConfigReturn();
+
+        $this->eventClockMock->expects('microtime')->andReturn(1000);
+
+        $this->agentMock->expects('getTransaction')
+            ->with(self::COMMAND_NAME)
+            ->andReturn(null);
+
+        $this->agentMock->expects('startTransaction')
+            ->with(self::COMMAND_NAME, [], 1000)
+            ->andReturn($this->transactionMock);
+
+        $this->dispatcher->dispatch(new ScheduledTaskStarting($this->eventMock));
+    }
+
+    public function testScheduledTaskSkippedListener(): void
+    {
+        $this->patternConfigReturn();
+
+        $this->agentMock->expects('getTransaction')
+            ->with(self::COMMAND_NAME)
+            ->andReturn($this->transactionMock);
+
+        $this->agentMock->expects('stopTransaction')
+            ->with(self::COMMAND_NAME, ['result' => 0]);
+        $this->agentMock->expects('collectEvents')
+            ->with(self::COMMAND_NAME);
+
+        $this->dispatcher->dispatch(new ScheduledTaskSkipped($this->eventMock));
+    }
+
+    public function testScheduledTaskFinishedListener(): void
+    {
+        $this->patternConfigReturn();
+
+        $this->agentMock->expects('getTransaction')
+            ->with(self::COMMAND_NAME)
+            ->andReturn($this->transactionMock);
+
+        $this->agentMock->expects('stopTransaction')
+            ->with(self::COMMAND_NAME, ['result' => 0]);
+        $this->agentMock->expects('collectEvents')
+            ->with(self::COMMAND_NAME);
+        $this->agentMock->expects('send');
+
+        $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0));
+    }
+
+    public function testCommandFinishedButExceptionThrownOnSend(): void
+    {
+        $this->patternConfigReturn();
+
+        $this->agentMock->expects('getTransaction')
+            ->with(self::COMMAND_NAME)
+            ->andReturn($this->transactionMock);
+        $this->agentMock->expects('stopTransaction')
+            ->with(self::COMMAND_NAME, ['result' => 0]);
+        $this->agentMock->expects('collectEvents')
+            ->with(self::COMMAND_NAME);
+        
+        $expectedLogMessage = 'snowball';
+        $this->agentMock->expects('send')
+            ->andThrow(new Exception($expectedLogMessage));
+
+        Log::shouldReceive('error')->once()->with($expectedLogMessage);
+
+        $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0)
+        );
     }
 }

--- a/tests/unit/Collectors/ScheduledTaskCollectorTest.php
+++ b/tests/unit/Collectors/ScheduledTaskCollectorTest.php
@@ -190,7 +190,6 @@ class ScheduledTaskCollectorTest extends Unit
 
         Log::shouldReceive('error')->once()->with($expectedLogMessage);
 
-        $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0)
-        );
+        $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0));
     }
 }

--- a/tests/unit/Collectors/ScheduledTaskCollectorTest.php
+++ b/tests/unit/Collectors/ScheduledTaskCollectorTest.php
@@ -183,7 +183,7 @@ class ScheduledTaskCollectorTest extends Unit
             ->with(self::COMMAND_NAME, ['result' => 0]);
         $this->agentMock->expects('collectEvents')
             ->with(self::COMMAND_NAME);
-        
+
         $expectedLogMessage = 'snowball';
         $this->agentMock->expects('send')
             ->andThrow(new Exception($expectedLogMessage));


### PR DESCRIPTION
Added the last round of tests before the final 2.0 release, in this case for `ScheduledTaskCollector` class. I also changed the following:
- Change the transaction check conditions for `*Starting` events, to be in line with the rest of the listeners.
- Use the command exit code instead of hardcoded `200`.