### PR TITLE
chore: remove check for Laravel 6 class

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -164,10 +164,7 @@ class ServiceProvider extends BaseServiceProvider
             $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
         } else {
             $this->app->tag(CommandCollector::class, self::COLLECTOR_TAG);
-            // Laravel ^6.0
-            if (class_exists('Illuminate\Console\Events\ScheduledTaskStarting')) {
-                $this->app->tag(ScheduledTaskCollector::class, self::COLLECTOR_TAG);
-            }
+            $this->app->tag(ScheduledTaskCollector::class, self::COLLECTOR_TAG);
         }
 
         // Job collector


### PR DESCRIPTION
Since we only support L6 from now on, there's no need for the class existence check.