### PR TITLE
fix: restore job type case

### DIFF
--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -79,7 +79,7 @@ class JobCollector extends EventDataCollector implements DataCollector
     protected function setTransactionType(string $transaction_name): void
     {
         $this->agent->getTransaction($transaction_name)->setMeta([
-            'type' => 'Job',
+            'type' => 'job',
         ]);
     }
 


### PR DESCRIPTION
Elastic is case sensitive, and having `Job` as type will create a new group of events. To avoid nasty surprises, let's keep it lowercase.