### PR TITLE
fix(config): default value for MAXTRACEITEMS env variable

### DIFF
--- a/src/Collectors/EventCounter.php
+++ b/src/Collectors/EventCounter.php
@@ -4,10 +4,12 @@ namespace AG\ElasticApmLaravel\Collectors;
 
 class EventCounter
 {
+    public const EVENT_LIMIT = 1000;
+
     private $limit;
     private $count = 0;
 
-    public function __construct(?int $limit = 1000)
+    public function __construct(?int $limit = self::EVENT_LIMIT)
     {
         $this->limit = $limit;
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -97,7 +97,7 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerAgent(): void
     {
         $this->app->singleton(EventCounter::class, function () {
-            $limit = config('elastic-apm-laravel.spans.maxTraceItems');
+            $limit = config('elastic-apm-laravel.spans.maxTraceItems', EventCounter::EVENT_LIMIT);
 
             return new EventCounter($limit);
         });


### PR DESCRIPTION
There was no default value for `MAXTRACEITEMS` env variable, leading to no spans being recorded, as `null` was the default value.