### PR TITLE
Ensure proper default is used when APM_APPNAME is empty

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -206,10 +206,30 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function getAgentConfig(): array
     {
+        /*
+         * Changes in how the Agent package uses environment variables impacted this package. Previous versions
+         * required the service name to be set with the `APM_APPNAME` environment variable. The underlying Agent
+         * package can now use `ELASTIC_APM_SERVICE_NAME` to get the value directly. A new `defaultServiceName`
+         * option is available which is used if the service name is not provided.
+         *
+         * In order to provide backward compatibility with existing configurations, we want to set the default
+         * service name in the Agent config to the value derived from the `APM_APPNAME` in the Laravel config.
+         * The user can still use `ELASTIC_APM_SERVICE_NAME` if desired.
+         *
+         * When using Laravel's config() helper, be aware that the default value "will be returned if the
+         * configuration option does not exist". Because the 'elastic-apm-laravel.app.appName' is _always_
+         * defined, a default value will never be used. Therefore, we must use additional logic to determine
+         * if an app name has been given.
+         */
+        $appName = config('elastic-apm-laravel.app.appName');
+        if (empty($appName)) {
+            $appName = 'Laravel';
+        }
+
         // Filter out null config options so that the Config class can look for environment variables
         return array_filter(array_merge(
             [
-                'defaultServiceName' => config('elastic-apm-laravel.app.appName', 'Laravel'),
+                'defaultServiceName' => $appName,
                 'frameworkName' => 'Laravel',
                 'frameworkVersion' => app()->version(),
                 'active' => config('elastic-apm-laravel.active'),

--- a/tests/config/ApmConfigTest.php
+++ b/tests/config/ApmConfigTest.php
@@ -6,9 +6,9 @@ class ApmConfigTest extends \Codeception\Test\Unit
 {
     private $configFilePath = __DIR__ . '/../../config/elastic-apm-laravel.php';
 
-    protected function _before()
+    protected function _after()
     {
-        // Make sure all environment variables are unset before every spec
+        // Make sure all environment variables are unset after every spec
         putenv('APM_ACTIVE');
         putenv('APM_APPNAME');
         putenv('APM_APPVERSION');


### PR DESCRIPTION
Closes #122 

I think this addresses the issue described in #122. This behavior results from how the Laravel `config()` helper works and relates to the use of the Agent package default service name. I added an extensive comment in the ServiceProvider to explain what appears to be unnecessarily complex code.