### PR TITLE
fix: always initialize an Agent and a Transaction

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -39,10 +39,6 @@ class ServiceProvider extends BaseServiceProvider
         // Always available, even when inactive
         $this->registerFacades();
 
-        if ($this->isAgentDisabled()) {
-            return;
-        }
-
         // Create a single representation of the request start time which can be injected
         // to other classes.
         $this->app->singleton(RequestStartTime::class, function () {
@@ -50,7 +46,10 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         $this->registerAgent();
-        $this->registerCollectors();
+
+        if (!$this->isAgentDisabled()) {
+            $this->registerCollectors();
+        }
     }
 
     /**
@@ -60,10 +59,6 @@ class ServiceProvider extends BaseServiceProvider
     public function boot(): void
     {
         $this->publishConfig();
-
-        if ($this->isAgentDisabled()) {
-            return;
-        }
 
         $this->registerMiddleware();
 


### PR DESCRIPTION
We faced a situation when using facades, but having the package disabled with `APM_ACTIVE=false`, was making the application fail. The problem is that we don't initialize an Agent nor start a transaction when the package is not enabled, but, the `ApmAgent` facade expects those to exist, as it exposes functionality related to the Agent and the current transaction.

I made a change to always register the Agent and the middleware but not the collectors if the package is not enabled. This means that an instance of the Agent will always exist, a transaction will be created but no spans will be collected or send to APM.

Edit: there is still a small issue though. We don't create a transaction if it matches the `APM_IGNORE_PATTERNS` pattern, and `ApmAgent::getCurrentTransaction()` will throw an exception as well. I think we should always create a transaction, but don't collect event around it nor send it to APM if it needs to be ignored. @dstepe maybe something the underlying package should take care of?