### PR TITLE
Bug fix: Allow disabling via the config.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -222,19 +222,24 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         // Filter out null config options so that the Config class can look for environment variables
-        return array_filter(array_merge(
-            [
-                'defaultServiceName' => $appName,
-                'frameworkName' => 'Laravel',
-                'frameworkVersion' => app()->version(),
-                'active' => config('elastic-apm-laravel.active'),
-                'environment' => config('elastic-apm-laravel.env.environment'),
-                'logger' => Log::getLogger(),
-                'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
-            ],
-            $this->getAppConfig(),
-            config('elastic-apm-laravel.server')
-        ));
+        return array_filter(
+            array_merge(
+                [
+                    'defaultServiceName' => $appName,
+                    'frameworkName' => 'Laravel',
+                    'frameworkVersion' => app()->version(),
+                    'active' => config('elastic-apm-laravel.active'),
+                    'environment' => config('elastic-apm-laravel.env.environment'),
+                    'logger' => Log::getLogger(),
+                    'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
+                ],
+                $this->getAppConfig(),
+                config('elastic-apm-laravel.server')
+            ),
+            function ($item) {
+                return null !== $item;
+            }
+        );
     }
 
     protected function getAppConfig(): array


### PR DESCRIPTION
It was broken because array_filter only returns truthy items. When specifying false, it wouldn't pass through the config and would take the upstream's preferred env var instead, which defaults to true.