### PR TITLE
chore: replace deprecated jasny/persist-sql-query package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/routing": "^6 || ^7 || ^8",
         "illuminate/support": "^6 || ^7 || ^8",
         "illuminate/contracts": "^6 || ^7 || ^8",
-        "jasny/dbquery-mysql": "^2.0",
+        "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },
     "require-dev": {


### PR DESCRIPTION
```
Package jasny/dbquery-mysql is abandoned, you should avoid using it. Use jasny/persist-sql-query instead.
```

The new package is just a copy of the previous one, at least in the existing version. Looks like v3 will introduce some breaking changes.

Closes #128