### PR TITLE
[Fix] Add guard clause to ensure return type on getAppConfig

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -249,7 +249,7 @@ class ServiceProvider extends BaseServiceProvider
             $config['appVersion'] = $this->app->make(VersionResolver::class)->getVersion();
         }
 
-        return $config;
+        return empty($config) ? [] : $config;
     }
 
     private function isAgentDisabled(): bool


### PR DESCRIPTION
This PR fixes the following error:
**Return value of AG\ElasticApmLaravel\ServiceProvider::getAppConfig() must be of the type array, null returned**

It happens if the laravel config files are cached and the project is auto-discoverable the call to the config file will return null and the app will crash due to the return type. It can be solved by running "php artisan config:clear", this PR will make the app not to crash if the files are cached.