### PR TITLE
Apply fixes for cached config when using environment variables to 2.x…

### DIFF
--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -2,7 +2,7 @@
 
 return [
     // Sets whether the apm reporting should be active or not
-    'active' => env('APM_ACTIVE'),
+    'active' => env('APM_ACTIVE', env('ELASTIC_APM_ENABLED', true)),
 
     'log-level' => env('APM_LOG_LEVEL', 'error'),
 
@@ -13,10 +13,10 @@ return [
 
     'app' => [
         // The app name that will identify your app in Kibana / Elastic APM, limited characters allowed
-        'appName' => preg_replace('/[^a-zA-Z0-9 _-]/', '-', env('APM_APPNAME')),
+        'appName' => preg_replace('/[^a-zA-Z0-9 _-]/', '-', env('APM_APPNAME', env('ELASTIC_APM_SERVICE_NAME', 'Laravel'))),
 
         // The version of your app
-        'appVersion' => env('APM_APPVERSION'),
+        'appVersion' => env('APM_APPVERSION', env('ELASTIC_APM_SERVICE_VERSION')),
     ],
 
     'env' => [
@@ -24,18 +24,22 @@ return [
         'env' => ['DOCUMENT_ROOT', 'REMOTE_ADDR'],
 
         // Application environment
-        'environment' => env('APM_ENVIRONMENT'),
+        'environment' => env('APM_ENVIRONMENT', 'development'),
     ],
 
     'server' => [
         // The apm-server to connect to
-        'serverUrl' => env('APM_SERVERURL'),
+        'serverUrl' => env('APM_SERVERURL', env('ELASTIC_APM_SERVER_URL', 'http://127.0.0.1:8200')),
 
         // Token for x
-        'secretToken' => env('APM_SECRETTOKEN'),
+        'secretToken' => env('APM_SECRETTOKEN', env('ELASTIC_APM_SECRET_TOKEN')),
 
         // Hostname of the system the agent is running on.
-        'hostname' => null,
+        'hostname' => env('ELASTIC_APM_HOSTNAME', gethostname()),
+    ],
+
+    'agent' => [
+        'transactionSampleRate' => env('ELASTIC_APM_TRANSACTION_SAMPLE_RATE', 1),
     ],
 
     'transactions' => [
@@ -50,7 +54,7 @@ return [
         'maxTraceItems' => env('APM_MAXTRACEITEMS', 1000),
 
         // Depth of backtraces
-        'backtraceDepth' => env('APM_BACKTRACEDEPTH'),
+        'backtraceDepth' => env('APM_BACKTRACEDEPTH', env('ELASTIC_APM_STACK_TRACE_LIMIT', 25)),
 
         'querylog' => [
             // Set to false to completely disable query logging, or to 'auto' if you would like to use the threshold feature.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -199,31 +199,9 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function getAgentConfig(): array
     {
-        /*
-         * Changes in how the Agent package uses environment variables impacted this package. Previous versions
-         * required the service name to be set with the `APM_APPNAME` environment variable. The underlying Agent
-         * package can now use `ELASTIC_APM_SERVICE_NAME` to get the value directly. A new `defaultServiceName`
-         * option is available which is used if the service name is not provided.
-         *
-         * In order to provide backward compatibility with existing configurations, we want to set the default
-         * service name in the Agent config to the value derived from the `APM_APPNAME` in the Laravel config.
-         * The user can still use `ELASTIC_APM_SERVICE_NAME` if desired.
-         *
-         * When using Laravel's config() helper, be aware that the default value "will be returned if the
-         * configuration option does not exist". Because the 'elastic-apm-laravel.app.appName' is _always_
-         * defined, a default value will never be used. Therefore, we must use additional logic to determine
-         * if an app name has been given.
-         */
-        $appName = config('elastic-apm-laravel.app.appName');
-        if (empty($appName)) {
-            $appName = 'Laravel';
-        }
-
-        // Filter out null config options so that the Config class can look for environment variables
-        return array_filter(
-            array_merge(
+        return array_merge(
                 [
-                    'defaultServiceName' => $appName,
+                    'defaultServiceName' => config('elastic-apm-laravel.app.appName'),
                     'frameworkName' => 'Laravel',
                     'frameworkVersion' => app()->version(),
                     'active' => config('elastic-apm-laravel.active'),
@@ -232,12 +210,9 @@ class ServiceProvider extends BaseServiceProvider
                     'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
                 ],
                 $this->getAppConfig(),
-                config('elastic-apm-laravel.server')
-            ),
-            function ($item) {
-                return null !== $item;
-            }
-        );
+                config('elastic-apm-laravel.server'),
+                config('elastic-apm-laravel.agent')
+            );
     }
 
     private function getLogInstance()

--- a/tests/config/ApmConfigTest.php
+++ b/tests/config/ApmConfigTest.php
@@ -6,6 +6,9 @@ class ApmConfigTest extends \Codeception\Test\Unit
 {
     private $configFilePath = __DIR__ . '/../../config/elastic-apm-laravel.php';
 
+    /** @var array */
+    private $config;
+
     protected function _after()
     {
         // Make sure all environment variables are unset after every spec
@@ -20,35 +23,43 @@ class ApmConfigTest extends \Codeception\Test\Unit
         putenv('APM_BACKTRACEDEPTH');
         putenv('APM_QUERYLOG');
         putenv('APM_THRESHOLD');
+
+        putenv('ELASTIC_APM_ENABLED');
+        putenv('ELASTIC_APM_SERVICE_NAME');
+        putenv('ELASTIC_APM_SERVER_URL');
+        putenv('ELASTIC_APM_SERVICE_VERSION');
+        putenv('ELASTIC_APM_SECRET_TOKEN');
+        putenv('ELASTIC_APM_HOSTNAME');
+        putenv('ELASTIC_APM_STACK_TRACE_LIMIT');
+        putenv('ELASTIC_APM_TRANSACTION_SAMPLE_RATE');
     }
 
     public function testDefaultValues()
     {
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        // Defer defaults to the Agent package in order to support configuration through environment variables
-        $this->assertEmpty($config['active']);
-        $this->assertEmpty($config['app']['appName']);
-        $this->assertEmpty($config['env']['environment']);
-        $this->assertEmpty($config['server']['serverUrl']);
-        $this->assertEmpty($config['spans']['backtraceDepth']);
+        $this->assertTrue($this->config['active']);
+        $this->assertEquals('http://127.0.0.1:8200', $this->config['server']['serverUrl']);
 
         // app block
-        $this->assertEquals('', $config['app']['appVersion']);
+        $this->assertEquals('Laravel', $this->config['app']['appName']);
+        $this->assertEquals('', $this->config['app']['appVersion']);
 
         // env block
-        $this->assertEquals(['DOCUMENT_ROOT', 'REMOTE_ADDR'], $config['env']['env']);
+        $this->assertEquals(['DOCUMENT_ROOT', 'REMOTE_ADDR'], $this->config['env']['env']);
+        $this->assertEquals('development', $this->config['env']['environment']);
 
         // server block
-        $this->assertNull($config['server']['secretToken']);
+        $this->assertNull($this->config['server']['secretToken']);
 
         // transactions block
-        $this->assertTrue($config['transactions']['useRouteUri']);
+        $this->assertTrue($this->config['transactions']['useRouteUri']);
 
         // spans block
-        $this->assertEquals(1000, $config['spans']['maxTraceItems']);
-        $this->assertEquals(25, $config['spans']['querylog']['enabled']);
-        $this->assertEquals(200, $config['spans']['querylog']['threshold']);
+        $this->assertEquals(1000, $this->config['spans']['maxTraceItems']);
+        $this->assertEquals(25, $this->config['spans']['querylog']['enabled']);
+        $this->assertEquals(200, $this->config['spans']['querylog']['threshold']);
+        $this->assertEquals(25, $this->config['spans']['backtraceDepth']);
     }
 
     public function testAppConfigEnvVariables()
@@ -56,45 +67,45 @@ class ApmConfigTest extends \Codeception\Test\Unit
         putenv('APM_ACTIVE=false');
         putenv('APM_APPNAME="Codeception App"');
         putenv('APM_APPVERSION="1.0.0"');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertFalse($config['active']);
-        $this->assertEquals('Codeception App', $config['app']['appName']);
-        $this->assertEquals('1.0.0', $config['app']['appVersion']);
+        $this->assertFalse($this->config['active']);
+        $this->assertEquals('Codeception App', $this->config['app']['appName']);
+        $this->assertEquals('1.0.0', $this->config['app']['appVersion']);
     }
 
     public function testAppNameSpecialCharacters()
     {
         putenv('APM_APPNAME="Codeception?App"');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertEquals('Codeception-App', $config['app']['appName']);
+        $this->assertEquals('Codeception-App', $this->config['app']['appName']);
     }
 
     public function testEnvConfigVariables()
     {
         putenv('APM_ENVIRONMENT="production"');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertEquals('production', $config['env']['environment']);
+        $this->assertEquals('production', $this->config['env']['environment']);
     }
 
     public function testServerConfigEnvVariables()
     {
         putenv('APM_SERVERURL="https://cloud.elastic.io:8200"');
         putenv('APM_SECRETTOKEN="super_secret_value"');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertEquals('https://cloud.elastic.io:8200', $config['server']['serverUrl']);
-        $this->assertEquals('super_secret_value', $config['server']['secretToken']);
+        $this->assertEquals('https://cloud.elastic.io:8200', $this->config['server']['serverUrl']);
+        $this->assertEquals('super_secret_value', $this->config['server']['secretToken']);
     }
 
     public function testTransactionsConfigEnvVariables()
     {
         putenv('APM_USEROUTEURI=false');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertFalse($config['transactions']['useRouteUri']);
+        $this->assertFalse($this->config['transactions']['useRouteUri']);
     }
 
     public function testSpansConfigEnvVariables()
@@ -103,11 +114,76 @@ class ApmConfigTest extends \Codeception\Test\Unit
         putenv('APM_BACKTRACEDEPTH=10');
         putenv('APM_QUERYLOG="auto"');
         putenv('APM_THRESHOLD=50');
-        $config = include $this->configFilePath;
+        $this->config = include $this->configFilePath;
 
-        $this->assertEquals(10, $config['spans']['maxTraceItems']);
-        $this->assertEquals(10, $config['spans']['backtraceDepth']);
-        $this->assertEquals('auto', $config['spans']['querylog']['enabled']);
-        $this->assertEquals(50, $config['spans']['querylog']['threshold']);
+        $this->assertEquals(10, $this->config['spans']['maxTraceItems']);
+        $this->assertEquals(10, $this->config['spans']['backtraceDepth']);
+        $this->assertEquals('auto', $this->config['spans']['querylog']['enabled']);
+        $this->assertEquals(50, $this->config['spans']['querylog']['threshold']);
+    }
+
+    /**
+     * @dataProvider elasticApmVariableChecks
+     */
+    public function testSupportsElasticApmEnvironmentVariables(string $setVariable, string $configPath, $expected): void
+    {
+        putenv($setVariable);
+
+        $this->config = include $this->configFilePath;
+
+        $this->assertEquals($expected, $this->getConfigPathValue($configPath));
+    }
+
+    public function elasticApmVariableChecks(): array
+    {
+        return [
+            'ELASTIC_APM_ENABLED true' => ['ELASTIC_APM_ENABLED=true', 'active', true],
+            'ELASTIC_APM_ENABLED false' => ['ELASTIC_APM_ENABLED=false', 'active', false],
+            'ELASTIC_APM_SERVICE_NAME' => ['ELASTIC_APM_SERVICE_NAME=TestService', 'app.appName', 'TestService'],
+            'ELASTIC_APM_SERVER_URL' => ['ELASTIC_APM_SERVER_URL=https://example.com', 'server.serverUrl', 'https://example.com'],
+            'ELASTIC_APM_SERVICE_VERSION' => ['ELASTIC_APM_SERVICE_VERSION=8.0', 'app.appVersion', '8.0'],
+            'ELASTIC_APM_SECRET_TOKEN' => ['ELASTIC_APM_SECRET_TOKEN=abc123', 'server.secretToken', 'abc123'],
+            'ELASTIC_APM_HOSTNAME' => ['ELASTIC_APM_HOSTNAME=node1.example.com', 'server.hostname', 'node1.example.com'],
+            'ELASTIC_APM_STACK_TRACE_LIMIT' => ['ELASTIC_APM_STACK_TRACE_LIMIT=10', 'spans.backtraceDepth', '10'],
+            'ELASTIC_APM_TRANSACTION_SAMPLE_RATE' => ['ELASTIC_APM_TRANSACTION_SAMPLE_RATE=.5', 'agent.transactionSampleRate', '.5'],
+        ];
+    }
+
+    /**
+     * @dataProvider apmVariablePreferenceChecks
+     */
+    public function testPrefersApmEnvironmentVariables(string $apmVariable, string $elasticVariable, string $configPath, $expected): void
+    {
+        putenv($apmVariable);
+        putenv($elasticVariable);
+
+        $this->config = include $this->configFilePath;
+
+        $this->assertEquals($expected, $this->getConfigPathValue($configPath));
+    }
+
+    public function apmVariablePreferenceChecks(): array
+    {
+        return [
+            'APM_ACTIVE true' => ['APM_ACTIVE=true', 'ELASTIC_APM_ENABLED=false', 'active', true],
+            'APM_ACTIVE false' => ['APM_ACTIVE=false', 'ELASTIC_APM_ENABLED=true', 'active', false],
+            'APM_APPNAME' => ['APM_APPNAME=ApmTestService', 'ELASTIC_APM_SERVICE_NAME=TestService', 'app.appName', 'ApmTestService'],
+            'APM_APPVERSION' => ['APM_APPVERSION=7.0', 'ELASTIC_APM_SERVICE_VERSION=8.0', 'app.appVersion', '7.0'],
+            'APM_SERVERURL' => ['APM_SERVERURL=https://example2.com', 'ELASTIC_APM_SERVER_URL=https://example.com', 'server.serverUrl', 'https://example2.com'],
+            'APM_SECRETTOKEN' => ['APM_SECRETTOKEN=xyz789', 'ELASTIC_APM_SECRET_TOKEN=abc123', 'server.secretToken', 'xyz789'],
+            'APM_BACKTRACEDEPTH' => ['APM_BACKTRACEDEPTH=5', 'ELASTIC_APM_STACK_TRACE_LIMIT=10', 'spans.backtraceDepth', '5'],
+        ];
+    }
+
+    private function getConfigPathValue(string $path)
+    {
+        $keys = explode('.', $path);
+        $config = $this->config;
+
+        while ($key = array_shift($keys)) {
+            $config = $config[$key];
+        }
+
+        return $config;
     }
 }

--- a/tests/unit/AgentTest.php
+++ b/tests/unit/AgentTest.php
@@ -190,7 +190,7 @@ class AgentTest extends Unit
     {
         $this->connectorMock->shouldReceive('commit');
         $this->connectorMock->expects('putEvent')
-            ->withArgs(function (\Nipwaayoni\Events\EventBean $event) {
+            ->withArgs(function (Nipwaayoni\Events\EventBean $event) {
                 $this->assertEquals('metadata', $event->getEventType());
 
                 return true;


### PR DESCRIPTION
This applies the recent fix for cached configuration and ELASTIC_APM variables to the 2.x branch. The cherry pick was clean and all tests are still passing. I do not have immediate access to a suitable app to do a real-world test, though.