### PR TITLE
fix: fallback value for LARAVEL_START constant

### DIFF
--- a/src/Collectors/FrameworkCollector.php
+++ b/src/Collectors/FrameworkCollector.php
@@ -18,8 +18,12 @@ class FrameworkCollector extends EventDataCollector implements DataCollector
     {
         // Application and Laravel startup times
         // LARAVEL_START is defined at the entry point of the application
-        // https://github.com/laravel/laravel/blob/master/public/index.php#L10
-        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', LARAVEL_START);
+        // https://github.com/laravel/laravel/blob/507d499577e4f3edb51577e144b61e61de4fb57f/public/index.php#L6
+        // But for serverless applications like Vapor or Octane,
+        // the constant is not defined making the application fail.
+        $start_time = defined('LARAVEL_START') ? constant('LARAVEL_START') : microtime(true);
+
+        $this->startMeasure('app_boot', 'app', 'boot', 'App boot', $start_time);
 
         $this->app->booting(function () {
             $this->startMeasure('laravel_boot', 'laravel', 'boot', 'Laravel boot');


### PR DESCRIPTION
When the application is running in a serverless environment like Vapor or only bootstrapped once like Octane, the `index.php` file is never executed for every request, and thus, the constant `LARAVEL_START` is never defined.

I added a fallback in case the constant is not defined.

Closes #146