### PR TITLE
Fix `REQUEST_URI` missing and `ServiceProvider` active check

### DIFF
--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -146,7 +146,7 @@ class RecordTransaction
     protected function getRequestUri(): string
     {
         // Fallback to script file name, like index.php when URI is not provided
-        return parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? $_SERVER['SCRIPT_FILENAME'];
+        return parse_url($_SERVER['REQUEST_URI'] ?? null, PHP_URL_PATH) ?? $_SERVER['SCRIPT_FILENAME'];
     }
 
     protected function normalizeUri(string $uri): string

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,7 +59,11 @@ class ServiceProvider extends BaseServiceProvider
     public function boot(): void
     {
         $this->publishConfig();
-
+        
+        if ($this->isAgentDisabled()) {
+            return;
+        }
+        
         $this->registerMiddleware();
 
         // If not collecting http events, the http middleware will not be executed and an
@@ -155,7 +159,8 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         // Http request collector
-        if ($this->collectHttpEvents()) {
+        if ($this->
+            ()) {
             $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
         } else {
             $this->app->tag(CommandCollector::class, self::COLLECTOR_TAG);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -158,7 +158,7 @@ class ServiceProvider extends BaseServiceProvider
             $this->app->tag(DBQueryCollector::class, self::COLLECTOR_TAG);
         }
 
-        // Http request collector
+        // Http request collector 
         if ($this->collectHttpEvents()) {
             $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
         } else {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,11 +59,11 @@ class ServiceProvider extends BaseServiceProvider
     public function boot(): void
     {
         $this->publishConfig();
-        
+
         if ($this->isAgentDisabled()) {
             return;
         }
-        
+
         $this->registerMiddleware();
 
         // If not collecting http events, the http middleware will not be executed and an

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -158,7 +158,7 @@ class ServiceProvider extends BaseServiceProvider
             $this->app->tag(DBQueryCollector::class, self::COLLECTOR_TAG);
         }
 
-        // Http request collector 
+        // Http request collector
         if ($this->collectHttpEvents()) {
             $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
         } else {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -159,8 +159,7 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         // Http request collector
-        if ($this->
-            ()) {
+        if ($this->collectHttpEvents()) {
             $this->app->tag(HttpRequestCollector::class, self::COLLECTOR_TAG);
         } else {
             $this->app->tag(CommandCollector::class, self::COLLECTOR_TAG);


### PR DESCRIPTION
- Fix REQUEST_URI array missing

```
Undefined array key "REQUEST_URI"
```
  Add  null coalescing operator "??" to escape the undefined array key error. `$_SERVER['REQUEST_URI']` not always exist. Occurred when running with Laravel Octane

- Add isAgentDisabled in ServiceProvider boot
Even after disable the status in config, the middleware still running by default. So, by adding APM status check in ServiceProvider to ignore middleware to be executed.


