### PR TITLE
fix(config): replace legacy configuration properties

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -210,7 +210,7 @@ class ServiceProvider extends BaseServiceProvider
                     'defaultServiceName' => config('elastic-apm-laravel.app.appName'),
                     'frameworkName' => 'Laravel',
                     'frameworkVersion' => app()->version(),
-                    'active' => config('elastic-apm-laravel.active'),
+                    'enabled' => config('elastic-apm-laravel.active'),
                     'environment' => config('elastic-apm-laravel.env.environment'),
                     'logger' => Log::getLogger(),
                     'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
@@ -225,8 +225,11 @@ class ServiceProvider extends BaseServiceProvider
     {
         $config = config('elastic-apm-laravel.app');
         if ($this->app->bound(VersionResolver::class)) {
-            $config['appVersion'] = $this->app->make(VersionResolver::class)->getVersion();
+            $config['serviceVersion'] = $this->app->make(VersionResolver::class)->getVersion();
         }
+
+        //
+        unset($config['appName']);
 
         return $config;
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -228,7 +228,7 @@ class ServiceProvider extends BaseServiceProvider
             $config['serviceVersion'] = $this->app->make(VersionResolver::class)->getVersion();
         }
 
-        //
+        // appName is deprecated in favour of serviceVersion
         unset($config['appName']);
 
         return $config;


### PR DESCRIPTION
Replace legacy configuration property keys with new names. I'm not changing the names in the configuration file for backguards compatibility reasons.

https://github.com/nipwaayoni/elastic-apm-php-agent/blob/master/src/Config.php#L36

Closes https://github.com/arkaitzgarro/elastic-apm-laravel/issues/153