### PR TITLE
chore: support for Laravel 9

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1]
+                php: [8.0, 8.1]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1, 8.0]
+                php: [8.1]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3]
+                php: [8.1, 8.0, 7.4, 7.3]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3]
+                php: [8.0, 7.4, 7.3]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1, 8.0, 7.4, 7.3]
+                php: [8.1, 8.0]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,13 +8,18 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 8.1]
-                laravel: [8.*, 9.*]
+                php: [8.0]
+                laravel: [8.*]
                 include:
-                    - laravel: 9.*
-                      testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
+                # php: [8.0, 8.1]
+                # laravel: [8.*, 9.*]
+                # include:
+                #     - laravel: 9.*
+                #       testbench: 7.*
+                #     - laravel: 8.*
+                #       testbench: 6.*
 
         name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1]
-                laravel: [8.*]
+                laravel: [8.*, 9.*]
                 include:
                     - laravel: 9.*
                       testbench: 7.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1]
+                php: [8.0, 8.1]
                 laravel: [8.*, 9.*]
                 include:
                     - laravel: 8.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,18 +8,11 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0]
+                php: [8.1, 8.0]
                 laravel: [9.*]
                 include:
                     - laravel: 9.*
                       testbench: 7.*
-                # php: [8.0, 8.1]
-                # laravel: [8.*, 9.*]
-                # include:
-                #     - laravel: 9.*
-                #       testbench: 7.*
-                #     - laravel: 8.*
-                #       testbench: 6.*
 
         name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,11 +8,12 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3]
-                laravel: [9.*, 8.*, 7.*, 6.*]
+                php: [7.4, 7.3]
+                laravel: [8.*, 7.*, 6.*]
                 include:
                     - laravel: 9.*
                       testbench: 7.*
+                      php: 8.0
                     - laravel: 8.*
                       testbench: 6.*
                     - laravel: 7.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,9 +8,11 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0, 7.4, 7.3]
+                laravel: [9.*, 8.*, 7.*, 6.*]
                 include:
+                    - laravel: 9.*
+                      testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
                     - laravel: 7.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,18 +8,13 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0, 8.1]
+                laravel: [8.*]
                 include:
                     - laravel: 9.*
                       testbench: 7.*
-                      php: 8.0
                     - laravel: 8.*
                       testbench: 6.*
-                    - laravel: 7.*
-                      testbench: ^5.2
-                    - laravel: 6.*
-                      testbench: 4.*
 
         name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,10 @@ jobs:
         strategy:
             matrix:
                 php: [8.1]
-                laravel: [9.*]
+                laravel: [8.*, 9.*]
                 include:
+                    - laravel: 8.*
+                      testbench: 6.*
                     - laravel: 9.*
                       testbench: 7.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1]
+                php: [8.0]
                 laravel: [9.*]
                 include:
                     - laravel: 9.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,11 +8,11 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0]
-                laravel: [8.*]
+                php: [8.1]
+                laravel: [9.*]
                 include:
-                    - laravel: 8.*
-                      testbench: 6.*
+                    - laravel: 9.*
+                      testbench: 7.*
                 # php: [8.0, 8.1]
                 # laravel: [8.*, 9.*]
                 # include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1, 8.0]
+                php: [8.1]
                 laravel: [9.*]
                 include:
                     - laravel: 9.*

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ In order to minimize potential dependency conflicts, this package does not dicta
 Require this package with composer:
 
 ```bash
-# Laravel 6+
+# Laravel 8+ and PHP 8+
 composer require arkaitzgarro/elastic-apm-laravel
+
+# Laravel 6+
+composer require arkaitzgarro/elastic-apm-laravel:^3.0
 
 # Laravel 5.5 - 5.8
 composer require arkaitzgarro/elastic-apm-laravel:^2.0

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "AG\\ElasticApmLaravel\\": "src/"
         }
     },
-    "minimum-stability": "RC",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },
     "require-dev": {
-        "codeception/codeception": "^4.1.9",
-        "codeception/mockery-module": "^0.4.0",
+        "codeception/codeception": "^5",
+        "codeception/mockery-module": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "orchestra/testbench": "^7.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0"
     },
@@ -41,7 +41,7 @@
             "AG\\ElasticApmLaravel\\": "src/"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "RC",
     "prefer-stable": true,
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/database": "^8 || ^9",
         "illuminate/http": "^8 || ^9",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "codeception/codeception": "^4.1",
         "codeception/mockery-module": "^0.4.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0.2",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/database": "^8 || ^9",
         "illuminate/http": "^8 || ^9",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "codeception/codeception": "^5",
         "codeception/mockery-module": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.0 || ^7.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": "^7.3|^8.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/database": "^6 || ^7 || ^8 || ^9",
         "illuminate/http": "^6 || ^7 || ^8 || ^9",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },
     "require-dev": {
-        "codeception/codeception": "^4.1",
+        "codeception/codeception": "^4.1.9",
         "codeception/mockery-module": "^0.4.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": ">=7.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^6 || ^7 || ^8",
-        "illuminate/http": "^6 || ^7 || ^8",
-        "illuminate/routing": "^6 || ^7 || ^8",
-        "illuminate/support": "^6 || ^7 || ^8",
-        "illuminate/contracts": "^6 || ^7 || ^8",
+        "illuminate/database": "^6 || ^7 || ^8 || ^9",
+        "illuminate/http": "^6 || ^7 || ^8 || ^9",
+        "illuminate/routing": "^6 || ^7 || ^8 || ^9",
+        "illuminate/support": "^6 || ^7 || ^8 || ^9",
+        "illuminate/contracts": "^6 || ^7 || ^8 || ^9",
         "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^6 || ^7 || ^8 || ^9",
-        "illuminate/http": "^6 || ^7 || ^8 || ^9",
-        "illuminate/routing": "^6 || ^7 || ^8 || ^9",
-        "illuminate/support": "^6 || ^7 || ^8 || ^9",
-        "illuminate/contracts": "^6 || ^7 || ^8 || ^9",
+        "illuminate/database": "^8 || ^9",
+        "illuminate/http": "^8 || ^9",
+        "illuminate/routing": "^8 || ^9",
+        "illuminate/support": "^8 || ^9",
+        "illuminate/contracts": "^8 || ^9",
         "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^7.5"
     },

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -206,19 +206,19 @@ class ServiceProvider extends BaseServiceProvider
     protected function getAgentConfig(): array
     {
         return array_merge(
-                [
-                    'defaultServiceName' => config('elastic-apm-laravel.app.appName'),
-                    'frameworkName' => 'Laravel',
-                    'frameworkVersion' => app()->version(),
-                    'enabled' => config('elastic-apm-laravel.active'),
-                    'environment' => config('elastic-apm-laravel.env.environment'),
-                    'logger' => Log::getLogger(),
-                    'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
-                ],
-                $this->getAppConfig(),
-                config('elastic-apm-laravel.server'),
-                config('elastic-apm-laravel.agent')
-            );
+            [
+                'defaultServiceName' => config('elastic-apm-laravel.app.appName'),
+                'frameworkName' => 'Laravel',
+                'frameworkVersion' => app()->version(),
+                'enabled' => config('elastic-apm-laravel.active'),
+                'environment' => config('elastic-apm-laravel.env.environment'),
+                'logger' => Log::getLogger(),
+                'logLevel' => config('elastic-apm-laravel.log-level', 'error'),
+            ],
+            $this->getAppConfig(),
+            config('elastic-apm-laravel.server'),
+            config('elastic-apm-laravel.agent')
+        );
     }
 
     protected function getAppConfig(): array


### PR DESCRIPTION
Add support for Laravel 9, and drop older versions of Laravel (6 and 7) and PHP (7.3 and 7.4).

Tests are passing and I tested it in an application with HTTP requests, commands and scheduled tasks. Seems to be working as expected. It can be tested using the [v4.0.0-BETA-2](https://github.com/arkaitzgarro/elastic-apm-laravel/releases/tag/v4.0.0-BETA-2) tag.

Closes #156 