### PR TITLE
Default log level to INFO

### DIFF
--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -4,7 +4,7 @@ return [
     // Sets whether the apm reporting should be active or not
     'active' => env('APM_ACTIVE', env('ELASTIC_APM_ENABLED', true)),
 
-    'log-level' => env('APM_LOG_LEVEL', 'error'),
+    'log-level' => env('APM_LOG_LEVEL', 'info'),
 
     'cli' => [
         // Sets whether the apm reporting should also be active for non-HTTP requests


### PR DESCRIPTION
As per the documentation "The default log level for the agent package is info."

Ref: https://github.com/arkaitzgarro/elastic-apm-laravel#logging