### PR TITLE
Allow ELASTIC_APM_ENVIRONMENT in config

### DIFF
--- a/config/elastic-apm-laravel.php
+++ b/config/elastic-apm-laravel.php
@@ -24,7 +24,7 @@ return [
         'env' => ['DOCUMENT_ROOT', 'REMOTE_ADDR'],
 
         // Application environment
-        'environment' => env('APM_ENVIRONMENT', 'development'),
+        'environment' => env('APM_ENVIRONMENT', env('ELASTIC_APM_ENVIRONMENT', 'development')),
     ],
 
     'server' => [


### PR DESCRIPTION
Fixes #161 

Other config values were correctly looking for `APM_` first, then checking `ELASTIC_APM_`. The `environment` configuration was missed.