### PR TITLE
fix: schedule task name for closures and invokable objects

### DIFF
--- a/src/Collectors/CommandCollector.php
+++ b/src/Collectors/CommandCollector.php
@@ -9,7 +9,6 @@ use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Support\Facades\Log;
 use Nipwaayoni\Events\Transaction;
-use Throwable;
 
 /**
  * Collects info about ran commands.
@@ -75,7 +74,7 @@ class CommandCollector extends EventDataCollector implements DataCollector
             $this->agent->send();
         } catch (ClientException $exception) {
             Log::error($exception, ['api_response' => (string) $exception->getResponse()->getBody()]);
-        } catch (Throwable $t) {
+        } catch (\Throwable $t) {
             Log::error($t->getMessage());
         }
     }

--- a/src/Collectors/DBQueryCollector.php
+++ b/src/Collectors/DBQueryCollector.php
@@ -3,7 +3,6 @@
 namespace AG\ElasticApmLaravel\Collectors;
 
 use AG\ElasticApmLaravel\Contracts\DataCollector;
-use Exception;
 use Illuminate\Database\Events\QueryExecuted;
 use Jasny\DB\MySQL\QuerySplitter;
 
@@ -73,7 +72,7 @@ class DBQueryCollector extends EventDataCollector implements DataCollector
             }
 
             return $fallback;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $fallback;
         }
     }

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -11,7 +11,6 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Facades\Log;
 use Nipwaayoni\Events\Transaction;
-use Throwable;
 
 /**
  * Collects info about the job process.
@@ -114,7 +113,7 @@ class JobCollector extends EventDataCollector implements DataCollector
             }
         } catch (ClientException $exception) {
             Log::error($exception, ['api_response' => (string) $exception->getResponse()->getBody()]);
-        } catch (Throwable $t) {
+        } catch (\Throwable $t) {
             Log::error($t->getMessage());
         }
     }

--- a/src/Collectors/ScheduledTaskCollector.php
+++ b/src/Collectors/ScheduledTaskCollector.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\ClientException;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Nipwaayoni\Events\Transaction;
@@ -91,7 +92,9 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
      */
     protected function getTransactionName($event): string
     {
-        $transaction_name = $event->task->command;
+        $transaction_name = $event->task instanceof CallbackEvent
+            ? $event->task->getSummaryForDisplay()
+            : $event->task->command;
 
         return $this->shouldIgnoreTransaction($transaction_name) ? '' : $transaction_name;
     }

--- a/src/Collectors/ScheduledTaskCollector.php
+++ b/src/Collectors/ScheduledTaskCollector.php
@@ -11,7 +11,6 @@ use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Nipwaayoni\Events\Transaction;
-use Throwable;
 
 /**
  * Collects info about scheduled tasks.
@@ -80,7 +79,7 @@ class ScheduledTaskCollector extends EventDataCollector implements DataCollector
             $this->agent->send();
         } catch (ClientException $exception) {
             Log::error($exception, ['api_response' => (string) $exception->getResponse()->getBody()]);
-        } catch (Throwable $t) {
+        } catch (\Throwable $t) {
             Log::error($t->getMessage());
         }
     }

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -4,14 +4,12 @@ namespace AG\ElasticApmLaravel\Middleware;
 
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Collectors\RequestStartTime;
-use Closure;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Log;
 use Nipwaayoni\Events\Transaction;
 use Symfony\Component\HttpFoundation\Response;
-use Throwable;
 
 /**
  * This middleware will record a transaction from the moment the request hits the server, until the response is sent to the client.
@@ -42,7 +40,7 @@ class RecordTransaction
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, \Closure $next)
     {
         $transaction_name = $this->getTransactionName($request);
 
@@ -99,7 +97,7 @@ class RecordTransaction
             // Stop the transaction and measure the time
             $this->agent->stopTransaction($transaction_name);
             $this->agent->collectEvents($transaction_name);
-        } catch (Throwable $t) {
+        } catch (\Throwable $t) {
             Log::error($t->getMessage());
         }
     }

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -9,7 +9,6 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Nipwaayoni\Events\Transaction;
-use Throwable;
 
 class ApmCollectorService
 {
@@ -83,7 +82,7 @@ class ApmCollectorService
         );
     }
 
-    public function captureThrowable(Throwable $thrown, array $context = [], ?Transaction $parent = null)
+    public function captureThrowable(\Throwable $thrown, array $context = [], ?Transaction $parent = null)
     {
         if ($this->is_agent_disabled) {
             return;


### PR DESCRIPTION
Our implementation to get the transaction name for Scheduled Tasks, was expecting only commands, but it should also accepts closures, invokable objects and jobs. I took the implementation that [Laravel uses to print the scheduled](https://github.com/laravel/framework/blob/61eac9cae4717699ecb3941b16c3d775820d4ca2/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php#L167) name in the terminal. 

The linter was complaining, sorry for the extra diff.

Closes https://github.com/arkaitzgarro/elastic-apm-laravel/issues/171