### PR TITLE
chore: enable PHP 8.2 CI jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: laravel/framework
-    versions:
-    - ">= 6.a, < 7"

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 8.1]
+                php: [8.0, 8.1, 8.2]
 
         name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 8.1]
+                php: [8.0, 8.1, 8.2]
                 laravel: [8.*, 9.*, 10.*]
                 include:
                     - laravel: 10.*

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -115,7 +115,7 @@ class Agent extends NipwaayoniAgent
         });
     }
 
-    public function startTransaction(string $name, array $context = [], float $start = null): Transaction
+    public function startTransaction(string $name, array $context = [], ?float $start = null): Transaction
     {
         $transaction = parent::startTransaction($name, $context, $start);
         $this->setCurrentTransaction($transaction);

--- a/src/Collectors/EventDataCollector.php
+++ b/src/Collectors/EventDataCollector.php
@@ -67,9 +67,9 @@ abstract class EventDataCollector implements DataCollector
     public function startMeasure(
         string $name,
         string $type = 'request',
-        string $action = null,
-        string $label = null,
-        float $start_time = null
+        ?string $action = null,
+        ?string $label = null,
+        ?float $start_time = null
     ): void {
         $start = $start_time ?? $this->event_clock->microtime();
         if ($this->hasStartedMeasure($name)) {

--- a/src/Events/StartMeasuring.php
+++ b/src/Events/StartMeasuring.php
@@ -22,9 +22,9 @@ class StartMeasuring
     public function __construct(
         string $name,
         string $type = 'request',
-        ?string $action = null,
-        ?string $label = null,
-        ?float $start_time = null
+        string $action = null,
+        string $label = null,
+        float $start_time = null
     ) {
         $this->name = $name;
         $this->type = $type;

--- a/src/Events/StartMeasuring.php
+++ b/src/Events/StartMeasuring.php
@@ -22,9 +22,9 @@ class StartMeasuring
     public function __construct(
         string $name,
         string $type = 'request',
-        string $action = null,
-        string $label = null,
-        float $start_time = null
+        ?string $action = null,
+        ?string $label = null,
+        ?float $start_time = null
     ) {
         $this->name = $name;
         $this->type = $type;

--- a/src/Exception/MissingAppConfigurationException.php
+++ b/src/Exception/MissingAppConfigurationException.php
@@ -2,9 +2,11 @@
 
 namespace AG\ElasticApmLaravel\Exception;
 
+use Throwable;
+
 class MissingAppConfigurationException extends ElasticApmLaravelException
 {
-    public function __construct(int $code = 0, \Throwable $previous = null)
+    public function __construct(int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct('Use AgentBuilder::withAppConfig() to provide a configuration object.', $code, $previous);
     }

--- a/src/Exception/MissingAppConfigurationException.php
+++ b/src/Exception/MissingAppConfigurationException.php
@@ -2,11 +2,9 @@
 
 namespace AG\ElasticApmLaravel\Exception;
 
-use Throwable;
-
 class MissingAppConfigurationException extends ElasticApmLaravelException
 {
-    public function __construct(int $code = 0, ?Throwable $previous = null)
+    public function __construct(int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct('Use AgentBuilder::withAppConfig() to provide a configuration object.', $code, $previous);
     }

--- a/src/Exception/NoCurrentTransactionException.php
+++ b/src/Exception/NoCurrentTransactionException.php
@@ -2,11 +2,9 @@
 
 namespace AG\ElasticApmLaravel\Exception;
 
-use Throwable;
-
 class NoCurrentTransactionException extends ElasticApmLaravelException
 {
-    public function __construct(int $code = 0, ?Throwable $previous = null)
+    public function __construct(int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct('No transaction is currently registered. Ensure a transaction is started.', $code, $previous);
     }

--- a/src/Exception/NoCurrentTransactionException.php
+++ b/src/Exception/NoCurrentTransactionException.php
@@ -2,9 +2,11 @@
 
 namespace AG\ElasticApmLaravel\Exception;
 
+use Throwable;
+
 class NoCurrentTransactionException extends ElasticApmLaravelException
 {
-    public function __construct(int $code = 0, \Throwable $previous = null)
+    public function __construct(int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct('No transaction is currently registered. Ensure a transaction is started.', $code, $previous);
     }

--- a/src/Jobs/Middleware/RecordTransaction.php
+++ b/src/Jobs/Middleware/RecordTransaction.php
@@ -9,10 +9,7 @@ class RecordTransaction
     /**
      * Wrap the job processing in an APM transaction.
      *
-     * @param mixed    $job
      * @param callable $next
-     *
-     * @return mixed
      */
     public function handle($job, $next)
     {

--- a/src/Jobs/Middleware/RecordTransaction.php
+++ b/src/Jobs/Middleware/RecordTransaction.php
@@ -8,10 +8,8 @@ class RecordTransaction
 {
     /**
      * Wrap the job processing in an APM transaction.
-     *
-     * @param callable $next
      */
-    public function handle($job, $next)
+    public function handle(mixed $job, callable $next)
     {
         if (false === config('elastic-apm-laravel.active') || false === config('elastic-apm-laravel.cli.active')) {
             return $next($job);

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -37,8 +37,6 @@ class RecordTransaction
 
     /**
      * Handle an incoming request.
-     *
-     * @return mixed
      */
     public function handle(Request $request, \Closure $next)
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -187,8 +187,6 @@ class ServiceProvider extends BaseServiceProvider
 
     /**
      * Publish the config file.
-     *
-     * @param string $configPath
      */
     protected function publishConfig(): void
     {

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -44,10 +44,10 @@ class ApmCollectorService
     public function startMeasure(
         string $name,
         string $type = 'request',
-        ?string $action = null,
-        ?string $label = null,
-        ?float $start_time = null
-    ) {
+        string $action = null,
+        string $label = null,
+        float $start_time = null
+    ): void {
         $this->events->dispatch(
             new StartMeasuring(
                 $name,
@@ -62,7 +62,7 @@ class ApmCollectorService
     public function stopMeasure(
         string $name,
         array $params = []
-    ) {
+    ): void {
         $this->events->dispatch(
             new StopMeasuring(
                 $name,
@@ -82,7 +82,7 @@ class ApmCollectorService
         );
     }
 
-    public function captureThrowable(\Throwable $thrown, array $context = [], ?Transaction $parent = null)
+    public function captureThrowable(\Throwable $thrown, array $context = [], Transaction $parent = null): void
     {
         if ($this->is_agent_disabled) {
             return;

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -2,6 +2,7 @@
 
 namespace AG\ElasticApmLaravel\Services;
 
+use Throwable;
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Events\StartMeasuring;
 use AG\ElasticApmLaravel\Events\StopMeasuring;
@@ -13,12 +14,12 @@ use Nipwaayoni\Events\Transaction;
 class ApmCollectorService
 {
     /**
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var Application
      */
     protected $app;
 
     /**
-     * @var \Illuminate\Events\Dispatcher
+     * @var Dispatcher
      */
     protected $events;
 
@@ -44,9 +45,9 @@ class ApmCollectorService
     public function startMeasure(
         string $name,
         string $type = 'request',
-        string $action = null,
-        string $label = null,
-        float $start_time = null
+        ?string $action = null,
+        ?string $label = null,
+        ?float $start_time = null
     ): void {
         $this->events->dispatch(
             new StartMeasuring(
@@ -82,7 +83,7 @@ class ApmCollectorService
         );
     }
 
-    public function captureThrowable(\Throwable $thrown, array $context = [], Transaction $parent = null): void
+    public function captureThrowable(Throwable $thrown, array $context = [], ?Transaction $parent = null): void
     {
         if ($this->is_agent_disabled) {
             return;

--- a/src/Services/ApmCollectorService.php
+++ b/src/Services/ApmCollectorService.php
@@ -2,7 +2,6 @@
 
 namespace AG\ElasticApmLaravel\Services;
 
-use Throwable;
 use AG\ElasticApmLaravel\Agent;
 use AG\ElasticApmLaravel\Events\StartMeasuring;
 use AG\ElasticApmLaravel\Events\StopMeasuring;
@@ -83,7 +82,7 @@ class ApmCollectorService
         );
     }
 
-    public function captureThrowable(Throwable $thrown, array $context = [], ?Transaction $parent = null): void
+    public function captureThrowable(\Throwable $thrown, array $context = [], ?Transaction $parent = null): void
     {
         if ($this->is_agent_disabled) {
             return;

--- a/tests/unit/AgentTest.php
+++ b/tests/unit/AgentTest.php
@@ -21,13 +21,13 @@ class AgentTest extends Unit
     private $config;
     /** @var ContextCollection */
     private $context;
-    /** @var \Mockery\Mock|Connector */
+    /** @var Mockery\Mock|Connector */
     private $connectorMock;
-    /** @var \Mockery\Mock|EventFactoryInterface */
+    /** @var Mockery\Mock|EventFactoryInterface */
     private $eventFactoryMock;
     /** @var TransactionsStore */
     private $transactionStore;
-    /** @var \Mockery\Mock|Repository */
+    /** @var Mockery\Mock|Repository */
     private $appConfigMock;
     /** @var RequestStartTime */
     private $requestStartTime;
@@ -64,8 +64,8 @@ class AgentTest extends Unit
 
     public function testAddsCollector(): void
     {
-        /** @var \Mockery\Mock|\AG\ElasticApmLaravel\Contracts\DataCollector $collector */
-        $collector = Mockery::mock(\AG\ElasticApmLaravel\Collectors\SpanCollector::class)->makePartial();
+        /** @var Mockery\Mock|AG\ElasticApmLaravel\Contracts\DataCollector $collector */
+        $collector = Mockery::mock(AG\ElasticApmLaravel\Collectors\SpanCollector::class)->makePartial();
 
         $this->agent->addCollector($collector);
 
@@ -74,8 +74,8 @@ class AgentTest extends Unit
 
     public function testSetsSelfAsAgentWhenAddingCollector(): void
     {
-        /** @var \Mockery\Mock|\AG\ElasticApmLaravel\Contracts\DataCollector $collector */
-        $collector = Mockery::mock(\AG\ElasticApmLaravel\Collectors\SpanCollector::class)->makePartial();
+        /** @var Mockery\Mock|AG\ElasticApmLaravel\Contracts\DataCollector $collector */
+        $collector = Mockery::mock(AG\ElasticApmLaravel\Collectors\SpanCollector::class)->makePartial();
 
         $collector->shouldReceive('useAgent')->with($this->agent);
 
@@ -117,7 +117,7 @@ class AgentTest extends Unit
 
     public function testThrowsExceptionWhenNoCurrentTransaction(): void
     {
-        $this->expectException(\AG\ElasticApmLaravel\Exception\NoCurrentTransactionException::class);
+        $this->expectException(AG\ElasticApmLaravel\Exception\NoCurrentTransactionException::class);
 
         $this->agent->currentTransaction();
     }
@@ -222,12 +222,12 @@ class AgentTest extends Unit
     {
         $this->expectedCollectors = [
             'span' => [
-                'class' => \AG\ElasticApmLaravel\Collectors\SpanCollector::class,
+                'class' => AG\ElasticApmLaravel\Collectors\SpanCollector::class,
                 'eventCount' => 3,
                 'object' => null,
             ],
             'db-query' => [
-                'class' => \AG\ElasticApmLaravel\Collectors\DBQueryCollector::class,
+                'class' => AG\ElasticApmLaravel\Collectors\DBQueryCollector::class,
                 'eventCount' => 5,
                 'object' => null,
             ],
@@ -243,7 +243,7 @@ class AgentTest extends Unit
 
         // create collectors with events
         foreach (array_keys($this->expectedCollectors) as $type) {
-            /** @var \AG\ElasticApmLaravel\Collectors\EventDataCollector $collector */
+            /** @var AG\ElasticApmLaravel\Collectors\EventDataCollector $collector */
             $collector = new $this->expectedCollectors[$type]['class']($app, $config, $this->requestStartTime, $this->eventCounter, $this->eventClock);
 
             for ($i = 0; $i < $this->expectedCollectors[$type]['eventCount']; ++$i) {

--- a/tests/unit/AgentTest.php
+++ b/tests/unit/AgentTest.php
@@ -89,7 +89,7 @@ class AgentTest extends Unit
 
     public function testAssertsDoesHaveCurrentTransaction(): void
     {
-        $this->agent->setCurrentTransaction(new \Nipwaayoni\Events\Transaction('test-transaction', []));
+        $this->agent->setCurrentTransaction(new Nipwaayoni\Events\Transaction('test-transaction', []));
 
         $this->assertTrue($this->agent->hasCurrentTransaction());
     }
@@ -97,7 +97,7 @@ class AgentTest extends Unit
     public function testStartingTransactionSetsCurrentTransaction(): void
     {
         $this->eventFactoryMock->shouldReceive('newTransaction')
-            ->andReturn(new \Nipwaayoni\Events\Transaction('test-transaction', []));
+            ->andReturn(new Nipwaayoni\Events\Transaction('test-transaction', []));
 
         $this->assertFalse($this->agent->hasCurrentTransaction());
 
@@ -108,7 +108,7 @@ class AgentTest extends Unit
 
     public function testReturnsCurrentTransaction(): void
     {
-        $transaction = new \Nipwaayoni\Events\Transaction('test-transaction', []);
+        $transaction = new Nipwaayoni\Events\Transaction('test-transaction', []);
 
         $this->agent->setCurrentTransaction($transaction);
 
@@ -124,7 +124,7 @@ class AgentTest extends Unit
 
     public function testClearsCurrentTransaction(): void
     {
-        $this->agent->setCurrentTransaction(new \Nipwaayoni\Events\Transaction('test-transaction', []));
+        $this->agent->setCurrentTransaction(new Nipwaayoni\Events\Transaction('test-transaction', []));
 
         $this->assertTrue($this->agent->hasCurrentTransaction());
 
@@ -138,9 +138,9 @@ class AgentTest extends Unit
         $this->setupCollectors();
 
         $this->eventFactoryMock->shouldReceive('newTransaction')
-            ->andReturn(new \Nipwaayoni\Events\Transaction('test-transaction', []));
+            ->andReturn(new Nipwaayoni\Events\Transaction('test-transaction', []));
 
-        $spanMock = Mockery::mock(\Nipwaayoni\Events\Span::class);
+        $spanMock = Mockery::mock(Nipwaayoni\Events\Span::class);
 
         $this->eventFactoryMock->shouldReceive('newSpan')
             ->withArgs(function ($name) {
@@ -169,7 +169,7 @@ class AgentTest extends Unit
 
     public function testStartNewTransactionSetsAsCurrent(): void
     {
-        $transaction = new \Nipwaayoni\Events\Transaction('test-transaction', []);
+        $transaction = new Nipwaayoni\Events\Transaction('test-transaction', []);
 
         $this->eventFactoryMock->shouldReceive('newTransaction')
             ->andReturn($transaction);
@@ -183,7 +183,7 @@ class AgentTest extends Unit
     {
         $this->connectorMock->shouldReceive('commit');
 
-        $this->agent->setCurrentTransaction(new \Nipwaayoni\Events\Transaction('test-transaction', []));
+        $this->agent->setCurrentTransaction(new Nipwaayoni\Events\Transaction('test-transaction', []));
 
         $this->assertTrue($this->agent->hasCurrentTransaction());
 
@@ -235,7 +235,7 @@ class AgentTest extends Unit
 
         $this->totalEvents = 0;
 
-        $app = Mockery::mock(\Illuminate\Foundation\Application::class);
+        $app = Mockery::mock(Illuminate\Foundation\Application::class);
         // Expect the array accessor for `events` which returns an object with a listen() method
         $app->shouldReceive('offsetGet->listen');
 

--- a/tests/unit/Collectors/CommandCollectorTest.php
+++ b/tests/unit/Collectors/CommandCollectorTest.php
@@ -99,7 +99,7 @@ class CommandCollectorTest extends Unit
     public function testCommandStartingListenerIgnored(): void
     {
         $this->patternConfigReturn(self::COMMAND_IGNORE_PATTERN);
-        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+        $this->agentMock->shouldNotReceive('startTransaction', 'getTransaction');
 
         $this->dispatcher->dispatch(new CommandStarting(
             self::COMMAND_NAME,
@@ -111,7 +111,7 @@ class CommandCollectorTest extends Unit
     public function testCommandFinishedListenerIgnored(): void
     {
         $this->patternConfigReturn(self::COMMAND_IGNORE_PATTERN);
-        $this->agentMock->shouldNotReceive(['getTransaction', 'captureThrowable', 'stopTransaction']);
+        $this->agentMock->shouldNotReceive('getTransaction', 'captureThrowable', 'stopTransaction');
 
         $this->dispatcher->dispatch(new CommandFinished(
             self::COMMAND_NAME,

--- a/tests/unit/Collectors/EventDataCollectorTest.php
+++ b/tests/unit/Collectors/EventDataCollectorTest.php
@@ -17,15 +17,15 @@ class EventDataCollectorTest extends Unit
     /** @var EventDataCollector */
     private $eventDataCollector;
 
-    /** @var Application|\Mockery\Mock */
+    /** @var Application|Mockery\Mock */
     private $appMock;
-    /** @var Config|\Mockery\Mock */
+    /** @var Config|Mockery\Mock */
     private $configMock;
-    /** @var RequestStartTime|\Mockery\Mock */
+    /** @var RequestStartTime|Mockery\Mock */
     private $requestStartTimeMock;
     /** @var EventCounter */
     private $eventCounter;
-    /** @var EventClock|\Mockery\Mock */
+    /** @var EventClock|Mockery\Mock */
     private $eventClock;
 
     public static $registeredListeners = false;

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -36,16 +36,16 @@ class JobCollectorTest extends Unit
      */
     private $collector;
 
-    /** @var Agent|\Mockery\LegacyMockInterface|\Mockery\MockInterface */
+    /** @var Agent|Mockery\LegacyMockInterface|Mockery\MockInterface */
     private $agentMock;
 
-    /** @var Job|\Mockery\LegacyMockInterface|\Mockery\MockInterface */
+    /** @var Job|Mockery\LegacyMockInterface|Mockery\MockInterface */
     private $jobMock;
 
-    /** @var Transaction|\Mockery\LegacyMockInterface|\Mockery\MockInterface */
+    /** @var Transaction|Mockery\LegacyMockInterface|Mockery\MockInterface */
     private $transactionMock;
 
-    /** @var Config|\Mockery\LegacyMockInterface|\Mockery\MockInterface */
+    /** @var Config|Mockery\LegacyMockInterface|Mockery\MockInterface */
     private $configMock;
 
     protected function _before()

--- a/tests/unit/Collectors/ScheduledTaskCollectorTest.php
+++ b/tests/unit/Collectors/ScheduledTaskCollectorTest.php
@@ -99,7 +99,7 @@ class ScheduledTaskCollectorTest extends Unit
     {
         $this->eventMock->command = 'work:do';
         $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
-        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+        $this->agentMock->shouldNotReceive('startTransaction', 'getTransaction');
 
         $this->dispatcher->dispatch(new ScheduledTaskStarting($this->eventMock));
     }
@@ -108,7 +108,7 @@ class ScheduledTaskCollectorTest extends Unit
     {
         $this->eventMock->command = 'work:do';
         $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
-        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+        $this->agentMock->shouldNotReceive('startTransaction', 'getTransaction');
 
         $this->dispatcher->dispatch(new ScheduledTaskSkipped($this->eventMock));
     }
@@ -117,7 +117,7 @@ class ScheduledTaskCollectorTest extends Unit
     {
         $this->eventMock->command = 'work:do';
         $this->patternConfigReturn(self::TASK_IGNORE_PATTERN);
-        $this->agentMock->shouldNotReceive(['startTransaction', 'getTransaction']);
+        $this->agentMock->shouldNotReceive('startTransaction', 'getTransaction');
 
         $this->dispatcher->dispatch(new ScheduledTaskFinished($this->eventMock, 1000.0));
     }

--- a/tests/unit/Middleware/RecordTransactionTest.php
+++ b/tests/unit/Middleware/RecordTransactionTest.php
@@ -14,32 +14,32 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 class RecordTransactionTest extends Unit
 {
     /**
-     * @var AG\ElasticApmLaravel\Agent|\Mockery\MockInterface
+     * @var Agent|Mockery\MockInterface
      */
     private $agent;
 
     /**
-     * @var RequestStartTime|\Mockery\MockInterface
+     * @var RequestStartTime|Mockery\MockInterface
      */
     private $requestStartTimeMock;
 
     /**
-     * @var Illuminate\Http\Request
+     * @var Request
      */
     private $request;
 
     /**
-     * @var Response|\Mockery\MockInterface
+     * @var Response|Mockery\MockInterface
      */
     private $response;
 
     /**
-     * @var AG\ElasticApmLaravel\Middleware\RecordTransaction
+     * @var RecordTransaction
      */
     private $middleware;
 
     /**
-     * @var Nipwaayoni\Events\Transaction
+     * @var Transaction
      */
     private $transaction;
 

--- a/tests/unit/Services/ApmAgentServiceTest.php
+++ b/tests/unit/Services/ApmAgentServiceTest.php
@@ -26,7 +26,7 @@ class ApmAgentServiceTest extends Unit
 
     public function testGetsCurrentTransaction()
     {
-        $transaction = Mockery::mock(\Nipwaayoni\Events\Transaction::class);
+        $transaction = Mockery::mock(Nipwaayoni\Events\Transaction::class);
 
         $this->agentMock->shouldReceive('currentTransaction')
             ->once()
@@ -37,9 +37,9 @@ class ApmAgentServiceTest extends Unit
 
     public function testAddsTraceparentHeaderToRequest()
     {
-        $request = Mockery::mock(\Psr\Http\Message\RequestInterface::class);
+        $request = Mockery::mock(Psr\Http\Message\RequestInterface::class);
 
-        $transaction = Mockery::mock(\Nipwaayoni\Events\Transaction::class);
+        $transaction = Mockery::mock(Nipwaayoni\Events\Transaction::class);
 
         $this->agentMock->shouldReceive('currentTransaction')
             ->once()


### PR DESCRIPTION
Run linters and tests in PHP 8.2. I also fixed some lint problems related to optional paramenters.