### PR TITLE
chore: remove compatibility with older versions of Laravel

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
 
     name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,8 +19,6 @@ jobs:
             testbench: 9.*
         exclude:
           - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
             php: 8.1
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,20 +10,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
-        laravel: [8.*, 9.*, 10.*, 11.*]
+        php: [8.1, 8.2]
+        laravel: [10.*, 11.*]
         include:
           - laravel: 10.*
             testbench: 8.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 11.*
             testbench: 9.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": "^8.0.2",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^8|^9|^10.0|^11.0",
-        "illuminate/http": "^8|^9|^10.0|^11.0",
-        "illuminate/routing": "^8|^9|^10.0|^11.0",
-        "illuminate/support": "^8|^9|^10.0|^11.0",
-        "illuminate/contracts": "^8|^9|^10.0|^11.0",
+        "illuminate/database": "^10.0|^11.0",
+        "illuminate/http": "^10.0|^11.0",
+        "illuminate/routing": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "codeception/codeception": "^5",
         "codeception/mockery-module": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0|^3.0"
     },


### PR DESCRIPTION
Versions 8 and 9 of Laravel are not supported anymore. Remove PHP 8.0 as well.