### PR TITLE
feat: add support for Laravel 13

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4, 8.5]
 
     name: PHP${{ matrix.php }}
 
@@ -31,7 +31,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
-        laravel: ['11.*', '12.*']
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: ['11.*', '12.*', '13.*']
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 
@@ -38,7 +40,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": "^8.2.0",
+        "php": "^8.2",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/routing": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^8.0"
     },
@@ -28,7 +28,7 @@
         "codeception/codeception": "^5",
         "codeception/mockery-module": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0|^3.0"
     },

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,8 +17,6 @@ use AG\ElasticApmLaravel\Services\ApmAgentService;
 use AG\ElasticApmLaravel\Services\ApmCollectorService;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Nipwaayoni\Config;
@@ -114,7 +112,7 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         // Register a callback on terminating to send the events
-        $this->app->terminating(function (Request $request, Response $response) {
+        $this->app->terminating(function () {
             /** @var Agent $agent */
             $agent = $this->app->make(Agent::class);
 

--- a/tests/unit/Collectors/JobCollectorTest.php
+++ b/tests/unit/Collectors/JobCollectorTest.php
@@ -183,6 +183,12 @@ class JobCollectorTest extends Unit
             ->with(self::JOB_NAME)
             ->andReturn(null, $this->transactionMock, $this->transactionMock);
 
+        // For Laravel 11+
+        if (class_exists('\Illuminate\Support\Facades\Context')) {
+            Illuminate\Support\Facades\Context::shouldReceive('hydrate');
+            $this->jobMock->shouldReceive('payload');
+        }
+
         $this->dispatcher->dispatch(new JobProcessing('test', $this->jobMock));
     }
 


### PR DESCRIPTION
Extends Laravel compatibility to include version 13, following the same
  expand pattern used in #180 (L11) and #187 (L12).

  **Changes:**

  - `composer.json`: illuminate/* constraints extended to `^13.0`, testbench
    to `^11.0`, PHP constraint loosened from `^8.2.0` to `^8.2`
  - CI: added L13 + testbench 11.* to test matrix, added PHP 8.4 and 8.5
  - CI: replaced deprecated `::set-output` with `$GITHUB_OUTPUT` (was
    causing Lint job to fail on current runners)
  - `ServiceProvider`: removed unused `Request $request, Response $response`
    parameters from `terminating()` callback — injected by the container
    but never read inside the closure

  Supersedes #189.