### PR TITLE
chore: remove support for PHP 8.2 and Laravel 11

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.3]
 
     name: PHP${{ matrix.php }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
           composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        uses: paambaati/codeclimate-action@v2.7.4
+        uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: 23639f09f4ef515ddb5fea9baf90f9f5cd9bb5e0801cf1dc062d993a3d70d3eb
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,9 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
-        laravel: ['11.*', '12.*']
+        php: [8.3]
+        laravel: ['12.*']
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,10 +54,4 @@ jobs:
           composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: 23639f09f4ef515ddb5fea9baf90f9f5cd9bb5e0801cf1dc062d993a3d70d3eb
-        with:
-          coverageCommand: vendor/bin/codecept run --xml test_report.xml --coverage --coverage-html --coverage-xml
-          coverageLocations: |
-            ${{github.workspace}}/tests/_output/coverage.xml:clover
+        run: vendor/bin/codecept run --xml test_report.xml --coverage --coverage-html --coverage-xml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CircleCI](https://circleci.com/gh/arkaitzgarro/elastic-apm-laravel.svg?style=svg)](https://circleci.com/gh/arkaitzgarro/elastic-apm-laravel)
 [![Latest Stable Version](https://poser.pugx.org/arkaitzgarro/elastic-apm-laravel/v/stable)](https://packagist.org/packages/arkaitzgarro/elastic-apm-laravel)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/e5a66b9bf5161e299c8c/test_coverage)](https://codeclimate.com/github/arkaitzgarro/elastic-apm-laravel/test_coverage)
 [![License](https://poser.pugx.org/arkaitzgarro/elastic-apm-laravel/license)](https://packagist.org/packages/arkaitzgarro/elastic-apm-laravel)
 
 Elastic APM agent for v2 intake API. Compatible with Laravel 12+.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e5a66b9bf5161e299c8c/test_coverage)](https://codeclimate.com/github/arkaitzgarro/elastic-apm-laravel/test_coverage)
 [![License](https://poser.pugx.org/arkaitzgarro/elastic-apm-laravel/license)](https://packagist.org/packages/arkaitzgarro/elastic-apm-laravel)
 
-Elastic APM agent for v2 intake API. Compatible with Laravel 11+.
+Elastic APM agent for v2 intake API. Compatible with Laravel 12+.
 
 | Transactions list                             | Transaction detail                              |
 | --------------------------------------------- | ----------------------------------------------- |
@@ -35,7 +35,7 @@ In order to minimize potential dependency conflicts, this package does not dicta
 Require this package with composer:
 
 ```bash
-# Laravel 11+ and PHP 8.2+
+# Laravel 12+ and PHP 8.3+
 composer require arkaitzgarro/elastic-apm-laravel
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": "^8.2.0",
+        "php": "^8.3.0",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/database": "^12.0",
+        "illuminate/http": "^12.0",
+        "illuminate/routing": "^12.0",
+        "illuminate/support": "^12.0",
+        "illuminate/contracts": "^12.0",
         "jasny/persist-sql-query": "^2.0",
         "nipwaayoni/elastic-apm-php-agent": "^8.0"
     },
@@ -28,7 +28,7 @@
         "codeception/codeception": "^5",
         "codeception/mockery-module": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^10.0",
         "php-http/guzzle7-adapter": "^1.0.0",
         "symfony/service-contracts": "^2.0|^3.0"
     },

--- a/src/Collectors/JobCollector.php
+++ b/src/Collectors/JobCollector.php
@@ -107,7 +107,7 @@ class JobCollector extends EventDataCollector implements DataCollector
     protected function send(Job $job): void
     {
         try {
-            if (!($job instanceof SyncJob)) {
+            if (!$job instanceof SyncJob) {
                 // When using a queued driver, send/flush transaction to make room for the next job in the queue
                 $this->agent->send();
             }


### PR DESCRIPTION
- Laravel 11 is not supported anymore, and PHP 8.2 security support will end in December 2026. Time to remove them.
- Code Climate integration seems to be broken, I disabled it but coverage is still shown in CI output.
- This means a breaking change and major version bump on next release.